### PR TITLE
feat: comprehensive namespace management for improved UX

### DIFF
--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -3,8 +3,11 @@ package cli
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/falseyair/tapio/internal/output"
 	"github.com/falseyair/tapio/pkg/simple"
@@ -48,6 +51,140 @@ func init() {
 	checkCmd.Flags().StringVarP(&outputFormat, "output", "o", "human", "Output format: human, json, yaml")
 }
 
+func showCurrentContext(request *types.CheckRequest) {
+	if request.All {
+		fmt.Printf("Checking all namespaces...\n\n")
+		return
+	}
+
+	namespace := request.Namespace
+	if namespace == "" {
+		// Get current namespace from context
+		namespace = getCurrentNamespace()
+		if namespace == "" {
+			namespace = "default"
+		}
+	}
+
+	fmt.Printf("Checking namespace: %s\n", namespace)
+	if request.Resource != "" {
+		fmt.Printf("Looking for: %s\n", request.Resource)
+	}
+	fmt.Println()
+}
+
+func handleNoResourceFound(resourceName, currentNamespace string) bool {
+	// Try to find the resource in other namespaces
+	suggestedNamespace, err := SuggestNamespaceForResource(resourceName)
+	if err != nil {
+		fmt.Printf("Resource '%s' not found in any namespace\n", resourceName)
+		fmt.Printf("Try: tapio check --all\n")
+		return true
+	}
+
+	// Ask if user wants to switch
+	if PromptForNamespaceSwitch(suggestedNamespace, resourceName) {
+		err := switchNamespace(suggestedNamespace)
+		if err != nil {
+			fmt.Printf("Failed to switch namespace: %v\n", err)
+			return true
+		}
+
+		fmt.Printf("Switched to namespace: %s\n", suggestedNamespace)
+		fmt.Printf("Re-run your command to check the resource\n")
+		return true
+	}
+
+	return false
+}
+
+func offerNamespaceSelection() bool {
+	fmt.Printf("No pods found in current namespace\n\n")
+	
+	checker, err := simple.NewChecker()
+	if err != nil {
+		return false
+	}
+
+	ctx := context.Background()
+	client := checker.GetClient()
+	nsList, err := client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false
+	}
+
+	fmt.Println("Available namespaces:")
+	namespacesWithPods := []string{}
+	
+	for _, ns := range nsList.Items {
+		pods, err := checker.GetPods(ctx, ns.Name, false)
+		podCount := 0
+		if err == nil {
+			podCount = len(pods)
+		}
+		
+		if podCount > 0 {
+			fmt.Printf("  %d. %s (%d pods)\n", len(namespacesWithPods)+1, ns.Name, podCount)
+			namespacesWithPods = append(namespacesWithPods, ns.Name)
+		}
+	}
+
+	if len(namespacesWithPods) == 0 {
+		fmt.Printf("No namespaces with pods found\n")
+		return true
+	}
+
+	fmt.Printf("\nSwitch to namespace [1-%d], 'a' for all, or Enter to cancel: ", len(namespacesWithPods))
+	
+	var input string
+	fmt.Scanln(&input)
+	
+	if input == "" {
+		return true
+	}
+
+	if input == "a" || input == "all" {
+		fmt.Printf("Run: tapio check --all\n")
+		return true
+	}
+
+	choice, err := strconv.Atoi(input)
+	if err != nil || choice < 1 || choice > len(namespacesWithPods) {
+		fmt.Printf("Invalid selection\n")
+		return true
+	}
+
+	selectedNamespace := namespacesWithPods[choice-1]
+	err = switchNamespace(selectedNamespace)
+	if err != nil {
+		fmt.Printf("Failed to switch namespace: %v\n", err)
+		return true
+	}
+
+	fmt.Printf("Switched to namespace: %s\n", selectedNamespace)
+	fmt.Printf("Re-run: tapio check\n")
+	return true
+}
+
+func getCurrentNamespace() string {
+	config, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
+	if err != nil {
+		return "default"
+	}
+
+	currentContext := config.CurrentContext
+	if currentContext == "" {
+		return "default"
+	}
+
+	context := config.Contexts[currentContext]
+	if context == nil || context.Namespace == "" {
+		return "default"
+	}
+
+	return context.Namespace
+}
+
 func runCheck(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
@@ -68,10 +205,30 @@ func runCheck(cmd *cobra.Command, args []string) error {
 		request.Resource = args[0]
 	}
 
+	// Show current context before check
+	showCurrentContext(request)
+
 	// Run the check
 	result, err := checker.Check(ctx, request)
 	if err != nil {
 		return fmt.Errorf("health check failed: %w", err)
+	}
+
+	// Check if the only problem is "No pods found" - this means we should offer alternatives
+	noPods := len(result.Problems) == 1 && result.Problems[0].Title == "No pods found"
+	
+	// If no pods found and specific resource requested, try smart suggestions
+	if noPods && request.Resource != "" && !request.All {
+		if handled := handleNoResourceFound(request.Resource, request.Namespace); handled {
+			return nil
+		}
+	}
+
+	// If no pods found in current namespace, offer interactive selection
+	if noPods && request.Resource == "" && !request.All {
+		if handled := offerNamespaceSelection(); handled {
+			return nil
+		}
 	}
 
 	// Output results

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -1,0 +1,321 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/falseyair/tapio/pkg/simple"
+)
+
+var contextCmd = &cobra.Command{
+	Use:   "context",
+	Short: "Show current Kubernetes context and namespace",
+	Long: `Display current Kubernetes cluster context and namespace information.
+	
+This helps you understand which cluster and namespace Tapio is currently targeting.`,
+	Example: `  # Show current context
+  tapio context
+  
+  # Show with cluster details
+  tapio context --verbose`,
+	RunE: runContext,
+}
+
+var useCmd = &cobra.Command{
+	Use:   "use [namespace]",
+	Short: "Switch to a different namespace",
+	Long: `Switch the current namespace context for Tapio commands.
+	
+This changes which namespace Tapio will target by default for subsequent commands.`,
+	Example: `  # Switch to a specific namespace
+  tapio use test-workloads
+  
+  # Interactive namespace selection
+  tapio use
+  
+  # Switch back to default
+  tapio use default`,
+	RunE: runUse,
+}
+
+func runContext(cmd *cobra.Command, args []string) error {
+	// Get current kubeconfig context
+	config, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
+	if err != nil {
+		return fmt.Errorf("failed to load kubeconfig: %w", err)
+	}
+
+	currentContext := config.CurrentContext
+	if currentContext == "" {
+		return fmt.Errorf("no current context set in kubeconfig")
+	}
+
+	kubeContext := config.Contexts[currentContext]
+	if kubeContext == nil {
+		return fmt.Errorf("context %s not found", currentContext)
+	}
+
+	namespace := kubeContext.Namespace
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	cluster := kubeContext.Cluster
+	user := kubeContext.AuthInfo
+
+	fmt.Printf("Tapio Context Information\n\n")
+	fmt.Printf("Current cluster: %s\n", cluster)
+	fmt.Printf("Current namespace: %s\n", namespace)
+	fmt.Printf("Current user: %s\n", user)
+	fmt.Printf("Kubeconfig context: %s\n", currentContext)
+
+	if verbose {
+		// Show additional details about the namespace
+		checker, err := simple.NewChecker()
+		if err != nil {
+			return fmt.Errorf("failed to create checker: %w", err)
+		}
+
+		ctx := context.Background()
+		pods, err := checker.GetPods(ctx, namespace, false)
+		if err == nil {
+			fmt.Printf("\nNamespace '%s' contains %d pods\n", namespace, len(pods))
+		}
+
+		// List available namespaces
+		fmt.Printf("\nAvailable namespaces:\n")
+		if err := showAvailableNamespaces(); err != nil {
+			fmt.Printf("  (Unable to list namespaces: %v)\n", err)
+		}
+	}
+
+	return nil
+}
+
+func runUse(cmd *cobra.Command, args []string) error {
+	var targetNamespace string
+
+	if len(args) == 0 {
+		// Interactive namespace selection
+		ns, err := selectNamespaceInteractively()
+		if err != nil {
+			return err
+		}
+		targetNamespace = ns
+	} else {
+		targetNamespace = args[0]
+	}
+
+	// Switch namespace by updating kubeconfig
+	err := switchNamespace(targetNamespace)
+	if err != nil {
+		return fmt.Errorf("failed to switch namespace: %w", err)
+	}
+
+	fmt.Printf("Switched to namespace: %s\n", targetNamespace)
+	fmt.Printf("All tapio commands will now target this namespace by default\n")
+	
+	return nil
+}
+
+func selectNamespaceInteractively() (string, error) {
+	checker, err := simple.NewChecker()
+	if err != nil {
+		return "", fmt.Errorf("failed to create checker: %w", err)
+	}
+
+	ctx := context.Background()
+	
+	// Get all namespaces
+	client := checker.GetClient()
+	nsList, err := client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to list namespaces: %w", err)
+	}
+
+	if len(nsList.Items) == 0 {
+		return "", fmt.Errorf("no namespaces found")
+	}
+
+	// Show current namespace
+	currentNS := getCurrentNamespace()
+	fmt.Printf("Current namespace: %s\n\n", currentNS)
+
+	fmt.Println("Available namespaces:")
+	
+	// Count pods in each namespace for context
+	namespacesWithCounts := make([]string, 0, len(nsList.Items))
+	for i, ns := range nsList.Items {
+		pods, err := checker.GetPods(ctx, ns.Name, false)
+		podCount := 0
+		if err == nil {
+			podCount = len(pods)
+		}
+		
+		status := ""
+		if ns.Name == currentNS {
+			status = " (current)"
+		}
+		
+		fmt.Printf("  %d. %s (%d pods)%s\n", i+1, ns.Name, podCount, status)
+		namespacesWithCounts = append(namespacesWithCounts, ns.Name)
+	}
+
+	fmt.Printf("\nSelect namespace [1-%d] or press Enter to cancel: ", len(nsList.Items))
+
+	var input string
+	fmt.Scanln(&input)
+
+	if input == "" {
+		return "", fmt.Errorf("cancelled")
+	}
+
+	choice, err := strconv.Atoi(input)
+	if err != nil || choice < 1 || choice > len(nsList.Items) {
+		return "", fmt.Errorf("invalid selection")
+	}
+
+	return namespacesWithCounts[choice-1], nil
+}
+
+func switchNamespace(namespace string) error {
+	// Load current kubeconfig
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	config, err := loadingRules.Load()
+	if err != nil {
+		return err
+	}
+
+	// Update the current context's namespace
+	currentContext := config.CurrentContext
+	if currentContext == "" {
+		return fmt.Errorf("no current context set")
+	}
+
+	if config.Contexts[currentContext] == nil {
+		return fmt.Errorf("context %s not found", currentContext)
+	}
+
+	config.Contexts[currentContext].Namespace = namespace
+
+	// Write back to kubeconfig
+	return clientcmd.WriteToFile(*config, loadingRules.GetDefaultFilename())
+}
+
+
+func showAvailableNamespaces() error {
+	checker, err := simple.NewChecker()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	client := checker.GetClient()
+	nsList, err := client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	currentNS := getCurrentNamespace()
+	
+	for _, ns := range nsList.Items {
+		pods, err := checker.GetPods(ctx, ns.Name, false)
+		podCount := 0
+		if err == nil {
+			podCount = len(pods)
+		}
+		
+		status := ""
+		if ns.Name == currentNS {
+			status = " (current)"
+		}
+		
+		fmt.Printf("  • %s (%d pods)%s\n", ns.Name, podCount, status)
+	}
+
+	return nil
+}
+
+// Helper function to suggest namespace when resource not found
+func SuggestNamespaceForResource(resourceName string) (string, error) {
+	checker, err := simple.NewChecker()
+	if err != nil {
+		return "", err
+	}
+
+	ctx := context.Background()
+	client := checker.GetClient()
+	
+	// Get all namespaces
+	nsList, err := client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	// Search for the resource in all namespaces
+	foundNamespaces := []string{}
+	
+	for _, ns := range nsList.Items {
+		pods, err := checker.GetPods(ctx, ns.Name, false)
+		if err != nil {
+			continue
+		}
+		
+		for _, pod := range pods {
+			if strings.Contains(pod.Name, resourceName) {
+				foundNamespaces = append(foundNamespaces, ns.Name)
+				break
+			}
+		}
+	}
+
+	if len(foundNamespaces) == 0 {
+		return "", fmt.Errorf("resource not found in any namespace")
+	}
+
+	if len(foundNamespaces) == 1 {
+		return foundNamespaces[0], nil
+	}
+
+	// Multiple matches - let user choose
+	fmt.Printf("Resource '%s' found in multiple namespaces:\n", resourceName)
+	for i, ns := range foundNamespaces {
+		fmt.Printf("  %d. %s\n", i+1, ns)
+	}
+	
+	fmt.Printf("Select namespace [1-%d]: ", len(foundNamespaces))
+	var input string
+	fmt.Scanln(&input)
+	
+	choice, err := strconv.Atoi(input)
+	if err != nil || choice < 1 || choice > len(foundNamespaces) {
+		return "", fmt.Errorf("invalid selection")
+	}
+
+	return foundNamespaces[choice-1], nil
+}
+
+// PromptForNamespaceSwitch asks user if they want to switch to suggested namespace
+func PromptForNamespaceSwitch(suggestedNamespace, resourceName string) bool {
+	fmt.Printf("Resource '%s' not found in current namespace.\n", resourceName)
+	fmt.Printf("Found in namespace: %s\n", suggestedNamespace)
+	fmt.Printf("Switch to %s? [Y/n]: ", suggestedNamespace)
+	
+	var input string
+	fmt.Scanln(&input)
+	
+	input = strings.ToLower(strings.TrimSpace(input))
+	return input == "" || input == "y" || input == "yes"
+}
+
+func init() {
+	// Add context and use commands to root
+	rootCmd.AddCommand(contextCmd)
+	rootCmd.AddCommand(useCmd)
+}


### PR DESCRIPTION
## Summary

This PR implements a comprehensive namespace management system to fix the critical UX issue where users couldn't easily find their resources or understand which namespace they were working in.

## Problem

Previously, when running `tapio check` commands, users would get "No pods found" errors even though pods existed in other namespaces. The tool defaulted to the empty `default` namespace with no clear indication of which namespace was being used.

## Solution

Implemented a three-pronged approach to namespace management:

### 1. Context-aware commands
- **`tapio context`** - Shows current cluster, namespace, and user information
- **`tapio use [namespace]`** - Switches namespaces persistently (updates kubeconfig)
  - Interactive namespace selection when no argument provided
  - Shows pod counts for each namespace

### 2. Smart auto-discovery  
- When a specific resource isn't found in the current namespace, tapio searches all namespaces
- Offers to switch to the correct namespace automatically
- Handles cases where resource exists in multiple namespaces

### 3. Interactive namespace selection
- When no pods are found in current namespace, shows available namespaces with pod counts
- Allows quick switching or suggests running with `--all` flag
- All namespace switches are persisted to kubeconfig

### 4. Namespace awareness in all commands
- All commands now show which namespace they're targeting
- `check` command shows "Checking namespace: X"

## Changes Made

- Added `GetClient()` and made `GetPods()` public in `checker.go` to enable namespace queries
- Added "No pods found" problem handling to provide helpful context
- Created comprehensive namespace management in `check.go`:
  - `showCurrentContext()` - displays which namespace is being checked
  - `handleNoResourceFound()` - smart suggestions when specific resources aren't found
  - `offerNamespaceSelection()` - interactive namespace switching
  - `getCurrentNamespace()` - reads current namespace from kubeconfig
- Created new `context.go` with namespace management commands:
  - `tapio context` command implementation
  - `tapio use` command implementation  
  - Helper functions for namespace discovery and switching

## Test Plan

- [x] Test `tapio context` shows current namespace/cluster
- [x] Test `tapio use test-workloads` switches namespaces
- [x] Test `tapio use` with interactive selection
- [x] Test `tapio check api-server` finds pod in other namespace and offers to switch
- [x] Test `tapio check` in empty namespace offers interactive selection
- [x] Test namespace persistence across commands

## Example Usage

```bash
# Check current context
$ tapio context
Tapio Context Information

Current cluster: kind-wgo-test
Current namespace: default
Current user: kind-wgo-test
Kubeconfig context: kind-wgo-test

# Check in empty namespace - offers selection
$ tapio check
Checking namespace: default

No pods found in current namespace

Available namespaces:
  1. kube-system (8 pods)
  2. local-path-storage (1 pods)  
  3. test-workloads (12 pods)

Switch to namespace [1-3], 'a' for all, or Enter to cancel: 3
Switched to namespace: test-workloads
Re-run: tapio check

# Smart auto-discovery
$ tapio check api-server
Checking namespace: default
Looking for: api-server

Resource 'api-server' not found in current namespace.
Found in namespace: test-workloads
Switch to test-workloads? [Y/n]: y
Switched to namespace: test-workloads
Re-run your command to check the resource

# Switch namespace
$ tapio use kube-system
Switched to namespace: kube-system
All tapio commands will now target this namespace by default
```

🤖 Generated with [Claude Code](https://claude.ai/code)