### PR TITLE
feat: integrate universal format with Prometheus metrics

### DIFF
--- a/pkg/correlation/rules/register.go
+++ b/pkg/correlation/rules/register.go
@@ -1,0 +1,40 @@
+package rules
+
+import (
+	"github.com/falseyair/tapio/pkg/correlation"
+)
+
+// RegisterDefaultRules registers all default correlation rules to the registry
+func RegisterDefaultRules(registry *correlation.RuleRegistry) error {
+	// Register OOM prediction rule
+	oomRule := NewOOMPredictionRule(DefaultOOMPredictionConfig())
+	if err := registry.RegisterRule(oomRule); err != nil {
+		return err
+	}
+
+	// Register memory leak detection rule
+	memLeakRule := NewMemoryLeakRule(DefaultMemoryLeakConfig())
+	if err := registry.RegisterRule(memLeakRule); err != nil {
+		return err
+	}
+
+	// Register CPU throttling rule
+	cpuThrottleRule := NewCPUThrottlingRule(DefaultCPUThrottlingConfig())
+	if err := registry.RegisterRule(cpuThrottleRule); err != nil {
+		return err
+	}
+
+	// Register crash loop detection rule
+	crashLoopRule := NewCrashLoopRule(DefaultCrashLoopConfig())
+	if err := registry.RegisterRule(crashLoopRule); err != nil {
+		return err
+	}
+
+	// Register disk pressure rule
+	diskPressureRule := NewDiskPressureRule(DefaultDiskPressureConfig())
+	if err := registry.RegisterRule(diskPressureRule); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/correlation/sources/ebpf.go
+++ b/pkg/correlation/sources/ebpf.go
@@ -1,0 +1,206 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/falseyair/tapio/pkg/correlation"
+	"github.com/falseyair/tapio/pkg/ebpf"
+)
+
+// EBPFDataSource implements DataSource interface for eBPF monitoring data
+type EBPFDataSource struct {
+	monitor ebpf.Monitor
+}
+
+// NewEBPFDataSource creates a new eBPF data source
+func NewEBPFDataSource(monitor ebpf.Monitor) *EBPFDataSource {
+	return &EBPFDataSource{
+		monitor: monitor,
+	}
+}
+
+// GetType returns the source type
+func (e *EBPFDataSource) GetType() correlation.SourceType {
+	return correlation.SourceEBPF
+}
+
+// IsAvailable checks if eBPF monitoring is available
+func (e *EBPFDataSource) IsAvailable() bool {
+	if e.monitor == nil {
+		return false
+	}
+	return e.monitor.IsAvailable()
+}
+
+// GetData retrieves data of the specified type
+func (e *EBPFDataSource) GetData(ctx context.Context, dataType string, params map[string]interface{}) (interface{}, error) {
+	switch dataType {
+	case "memory_stats":
+		return e.getMemoryStats(ctx, params)
+	case "ebpf_data":
+		return e.getEBPFData(ctx, params)
+	case "process_stats":
+		return e.getProcessStats(ctx, params)
+	case "memory_events":
+		return e.getMemoryEvents(ctx, params)
+	case "cpu_events":
+		return e.getCPUEvents(ctx, params)
+	case "io_events":
+		return e.getIOEvents(ctx, params)
+	default:
+		return nil, fmt.Errorf("unsupported data type: %s", dataType)
+	}
+}
+
+// getEBPFData retrieves comprehensive eBPF monitoring data
+func (e *EBPFDataSource) getEBPFData(ctx context.Context, params map[string]interface{}) (*correlation.EBPFData, error) {
+	// Get memory stats from monitor
+	stats, err := e.monitor.GetMemoryStats()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get memory stats: %w", err)
+	}
+	
+	// Convert to correlation format
+	processStats := make(map[uint32]*correlation.ProcessMemoryStats)
+	for _, stat := range stats {
+		processStats[stat.PID] = &correlation.ProcessMemoryStats{
+			PID:            stat.PID,
+			Command:        stat.Command,
+			TotalAllocated: stat.TotalAllocated,
+			TotalFreed:     stat.TotalFreed,
+			CurrentUsage:   stat.CurrentUsage,
+			AllocationRate: stat.AllocationRate,
+			LastUpdate:     stat.LastUpdate,
+			InContainer:    stat.InContainer,
+			ContainerPID:   stat.ContainerPID,
+			GrowthPattern:  convertGrowthPattern(stat.GrowthPattern),
+			// IOBytesWritten and IOBytesRead not available in ebpf.ProcessMemoryStats
+		}
+	}
+	
+	// Note: The current eBPF interface doesn't provide events or system metrics
+	// We'll create empty/default values for now
+	memoryEvents := []correlation.MemoryEvent{}
+	cpuEvents := []correlation.CPUEvent{}
+	ioEvents := []correlation.IOEvent{}
+	
+	return &correlation.EBPFData{
+		ProcessStats: processStats,
+		SystemMetrics: correlation.SystemMetrics{
+			// System metrics not available from current eBPF interface
+			Timestamp: time.Now(),
+		},
+		MemoryEvents: memoryEvents,
+		CPUEvents:    cpuEvents,
+		IOEvents:     ioEvents,
+		Timestamp:    time.Now(),
+	}, nil
+}
+
+// getMemoryStats retrieves memory statistics
+func (e *EBPFDataSource) getMemoryStats(ctx context.Context, params map[string]interface{}) (map[uint32]*correlation.ProcessMemoryStats, error) {
+	stats, err := e.monitor.GetMemoryStats()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get memory stats: %w", err)
+	}
+	
+	processStats := make(map[uint32]*correlation.ProcessMemoryStats)
+	for _, stat := range stats {
+		// Filter by PID if specified
+		if targetPID, ok := params["pid"].(uint32); ok && stat.PID != targetPID {
+			continue
+		}
+		
+		// Filter by container if specified
+		if inContainer, ok := params["in_container"].(bool); ok && stat.InContainer != inContainer {
+			continue
+		}
+		
+		processStats[stat.PID] = &correlation.ProcessMemoryStats{
+			PID:            stat.PID,
+			Command:        stat.Command,
+			TotalAllocated: stat.TotalAllocated,
+			TotalFreed:     stat.TotalFreed,
+			CurrentUsage:   stat.CurrentUsage,
+			AllocationRate: stat.AllocationRate,
+			LastUpdate:     stat.LastUpdate,
+			InContainer:    stat.InContainer,
+			ContainerPID:   stat.ContainerPID,
+			GrowthPattern:  convertGrowthPattern(stat.GrowthPattern),
+			// IOBytesWritten and IOBytesRead not available in ebpf.ProcessMemoryStats
+		}
+	}
+	
+	return processStats, nil
+}
+
+// getProcessStats retrieves process statistics
+func (e *EBPFDataSource) getProcessStats(ctx context.Context, params map[string]interface{}) (map[uint32]*correlation.ProcessMemoryStats, error) {
+	// This is an alias for getMemoryStats as they return the same data
+	return e.getMemoryStats(ctx, params)
+}
+
+// getMemoryEvents retrieves recent memory events
+func (e *EBPFDataSource) getMemoryEvents(ctx context.Context, params map[string]interface{}) ([]correlation.MemoryEvent, error) {
+	limit := 100
+	if l, ok := params["limit"].(int); ok {
+		limit = l
+	}
+	
+	return e.getRecentMemoryEvents(limit), nil
+}
+
+// getCPUEvents retrieves recent CPU events
+func (e *EBPFDataSource) getCPUEvents(ctx context.Context, params map[string]interface{}) ([]correlation.CPUEvent, error) {
+	limit := 100
+	if l, ok := params["limit"].(int); ok {
+		limit = l
+	}
+	
+	return e.getRecentCPUEvents(limit), nil
+}
+
+// getIOEvents retrieves recent IO events
+func (e *EBPFDataSource) getIOEvents(ctx context.Context, params map[string]interface{}) ([]correlation.IOEvent, error) {
+	limit := 100
+	if l, ok := params["limit"].(int); ok {
+		limit = l
+	}
+	
+	return e.getRecentIOEvents(limit), nil
+}
+
+// getRecentMemoryEvents retrieves recent memory events from the monitor
+func (e *EBPFDataSource) getRecentMemoryEvents(limit int) []correlation.MemoryEvent {
+	// Current eBPF interface doesn't provide event history
+	// Return empty slice for now
+	return []correlation.MemoryEvent{}
+}
+
+// getRecentCPUEvents retrieves recent CPU events from the monitor
+func (e *EBPFDataSource) getRecentCPUEvents(limit int) []correlation.CPUEvent {
+	// Current eBPF interface doesn't provide event history
+	// Return empty slice for now
+	return []correlation.CPUEvent{}
+}
+
+// getRecentIOEvents retrieves recent IO events from the monitor
+func (e *EBPFDataSource) getRecentIOEvents(limit int) []correlation.IOEvent {
+	// Current eBPF interface doesn't provide event history
+	// Return empty slice for now
+	return []correlation.IOEvent{}
+}
+
+// convertGrowthPattern converts eBPF growth pattern to correlation format
+func convertGrowthPattern(pattern []ebpf.MemoryDataPoint) []correlation.MemoryDataPoint {
+	points := make([]correlation.MemoryDataPoint, len(pattern))
+	for i, p := range pattern {
+		points[i] = correlation.MemoryDataPoint{
+			Timestamp: p.Timestamp,
+			Usage:     p.Usage,
+		}
+	}
+	return points
+}

--- a/pkg/correlation/sources/kubernetes.go
+++ b/pkg/correlation/sources/kubernetes.go
@@ -1,0 +1,192 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/falseyair/tapio/pkg/correlation"
+	"github.com/falseyair/tapio/pkg/simple"
+	"github.com/falseyair/tapio/pkg/types"
+)
+
+// KubernetesDataSource implements DataSource interface for Kubernetes data
+type KubernetesDataSource struct {
+	checker *simple.Checker
+}
+
+// NewKubernetesDataSource creates a new Kubernetes data source
+func NewKubernetesDataSource(checker *simple.Checker) *KubernetesDataSource {
+	return &KubernetesDataSource{
+		checker: checker,
+	}
+}
+
+// GetType returns the source type
+func (k *KubernetesDataSource) GetType() correlation.SourceType {
+	return correlation.SourceKubernetes
+}
+
+// IsAvailable checks if the Kubernetes API is available
+func (k *KubernetesDataSource) IsAvailable() bool {
+	// Check if we can access the API
+	client := k.checker.GetClient()
+	if client == nil {
+		return false
+	}
+	
+	// Try a simple API call
+	ctx := context.Background()
+	req := &types.CheckRequest{
+		Namespace: "default",
+		All:       false,
+	}
+	
+	_, err := k.checker.Check(ctx, req)
+	return err == nil
+}
+
+// GetData retrieves data of the specified type
+func (k *KubernetesDataSource) GetData(ctx context.Context, dataType string, params map[string]interface{}) (interface{}, error) {
+	switch dataType {
+	case "kubernetes_data":
+		return k.getKubernetesData(ctx, params)
+	case "pods":
+		return k.getPods(ctx, params)
+	case "events":
+		return k.getEvents(ctx, params)
+	case "problems":
+		return k.getProblems(ctx, params)
+	default:
+		return nil, fmt.Errorf("unsupported data type: %s", dataType)
+	}
+}
+
+// getKubernetesData retrieves comprehensive Kubernetes data
+func (k *KubernetesDataSource) getKubernetesData(ctx context.Context, params map[string]interface{}) (*correlation.KubernetesData, error) {
+	namespace := ""
+	all := true
+	
+	if ns, ok := params["namespace"].(string); ok {
+		namespace = ns
+		all = false
+	}
+	
+	// Get health check data
+	req := &types.CheckRequest{
+		Namespace: namespace,
+		All:       all,
+		Verbose:   true,
+	}
+	
+	result, err := k.checker.Check(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check health: %w", err)
+	}
+	
+	// Get pods
+	pods, err := k.checker.GetPods(ctx, namespace, all)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pods: %w", err)
+	}
+	
+	// Get events from pods
+	var events []corev1.Event
+	for _, pod := range pods {
+		podEvents, err := k.getEventsForPod(ctx, &pod)
+		if err == nil {
+			events = append(events, podEvents...)
+		}
+	}
+	
+	return &correlation.KubernetesData{
+		Pods:      pods,
+		Events:    events,
+		Problems:  result.Problems,
+		Metrics:   make(map[string]interface{}), // TODO: Add metrics if available
+		Timestamp: result.Timestamp,
+	}, nil
+}
+
+// getPods retrieves pods
+func (k *KubernetesDataSource) getPods(ctx context.Context, params map[string]interface{}) ([]corev1.Pod, error) {
+	namespace := ""
+	all := true
+	
+	if ns, ok := params["namespace"].(string); ok {
+		namespace = ns
+		all = false
+	}
+	
+	return k.checker.GetPods(ctx, namespace, all)
+}
+
+// getEvents retrieves events
+func (k *KubernetesDataSource) getEvents(ctx context.Context, params map[string]interface{}) ([]corev1.Event, error) {
+	namespace := ""
+	if ns, ok := params["namespace"].(string); ok {
+		namespace = ns
+	}
+	
+	// Get all pods first
+	pods, err := k.checker.GetPods(ctx, namespace, namespace == "")
+	if err != nil {
+		return nil, err
+	}
+	
+	// Collect events for all pods
+	var allEvents []corev1.Event
+	for _, pod := range pods {
+		events, err := k.getEventsForPod(ctx, &pod)
+		if err == nil {
+			allEvents = append(allEvents, events...)
+		}
+	}
+	
+	return allEvents, nil
+}
+
+// getEventsForPod retrieves events for a specific pod
+func (k *KubernetesDataSource) getEventsForPod(ctx context.Context, pod *corev1.Pod) ([]corev1.Event, error) {
+	// Get the client from checker
+	client := k.checker.GetClient()
+	if client == nil {
+		return nil, fmt.Errorf("kubernetes client not available")
+	}
+	
+	fieldSelector := fmt.Sprintf("involvedObject.name=%s,involvedObject.namespace=%s", pod.Name, pod.Namespace)
+	eventList, err := client.CoreV1().Events(pod.Namespace).List(ctx, metav1.ListOptions{
+		FieldSelector: fieldSelector,
+	})
+	if err != nil {
+		return nil, err
+	}
+	
+	return eventList.Items, nil
+}
+
+// getProblems retrieves problems by running health check
+func (k *KubernetesDataSource) getProblems(ctx context.Context, params map[string]interface{}) ([]types.Problem, error) {
+	namespace := ""
+	all := true
+	
+	if ns, ok := params["namespace"].(string); ok {
+		namespace = ns
+		all = false
+	}
+	
+	req := &types.CheckRequest{
+		Namespace: namespace,
+		All:       all,
+		Verbose:   true,
+	}
+	
+	result, err := k.checker.Check(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	
+	return result.Problems, nil
+}

--- a/pkg/universal/formatters/cli.go
+++ b/pkg/universal/formatters/cli.go
@@ -179,7 +179,8 @@ func (f *CLIFormatter) FormatExplanation(data *universal.UniversalDataset) strin
 	
 	// Group predictions by target
 	targetPredictions := make(map[string][]*universal.UniversalPrediction)
-	for _, pred := range data.Predictions {
+	for i := range data.Predictions {
+		pred := &data.Predictions[i]
 		key := f.formatTarget(pred.Target)
 		targetPredictions[key] = append(targetPredictions[key], pred)
 	}


### PR DESCRIPTION
## Summary
This PR integrates the Universal Data Format with Prometheus metrics output, enabling real-time intelligent analysis through the correlation engine.

## Changes
- ✨ Add correlation engine integration to PrometheusExporter
- 🔌 Create data source adapters for Kubernetes and eBPF  
- 📊 Implement real-time correlation analysis in metrics pipeline
- 🎨 Add universal format support to CLI commands (prometheus, why)
- 🐛 Fix compilation errors in universal formatters
- 📈 Enable correlation findings export as Prometheus metrics

## Key Features
1. **Real Data Flow**: eBPF data → Correlation Engine → Universal Format → Prometheus Metrics
2. **Intelligent Analysis**: Multiple correlation rules analyze patterns to generate predictions
3. **Enhanced CLI**: Both `tapio prometheus` and `tapio why` now use universal format by default

## Test Plan
- [ ] Run `tapio prometheus --universal` and verify metrics at http://localhost:8080/metrics
- [ ] Test `tapio why <pod-name> --universal` for enhanced explanations
- [ ] Verify correlation engine findings appear as Prometheus metrics
- [ ] Check eBPF integration with `--enable-ebpf` flag

## Related Work
- Builds on Agent 2's Universal Data Format implementation
- Completes Agent 4's Prometheus integration assignment

🤖 Generated with [Claude Code](https://claude.ai/code)