### PR TITLE
fix(ebpf): update rate limiter to use context parameter

### DIFF
--- a/pkg/collectors/ebpf/internal/collector_prod.go
+++ b/pkg/collectors/ebpf/internal/collector_prod.go
@@ -63,9 +63,9 @@ func NewProductionCollector(config core.Config) (core.Collector, error) {
 
 	// Initialize rate limiter
 	if config.MaxEventsPerSecond > 0 {
-		c.rateLimiter = NewRateLimiter(int64(config.MaxEventsPerSecond))
+		c.rateLimiter = NewRateLimiterSimple(int64(config.MaxEventsPerSecond))
 	} else {
-		c.rateLimiter = NewRateLimiter(10000) // Default 10k/sec
+		c.rateLimiter = NewRateLimiterSimple(10000) // Default 10k/sec
 	}
 
 	// Initialize platform-specific implementation
@@ -226,7 +226,7 @@ func (c *ProductionCollector) processEvents() {
 			}
 
 			// Apply rate limiting
-			if !c.rateLimiter.Allow() {
+			if !c.rateLimiter.Allow(c.ctx) {
 				c.stats.eventsDropped.Add(1)
 				continue
 			}

--- a/pkg/collectors/ebpf/internal/ratelimiter_test.go
+++ b/pkg/collectors/ebpf/internal/ratelimiter_test.go
@@ -1,0 +1,73 @@
+package internal
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestRateLimiterSimple(t *testing.T) {
+	// Test NewRateLimiterSimple
+	rl := NewRateLimiterSimple(100)
+	if rl == nil {
+		t.Fatal("NewRateLimiterSimple returned nil")
+	}
+
+	// Test Allow with context
+	ctx := context.Background()
+	allowed := rl.Allow(ctx)
+	if !allowed {
+		t.Error("First request should be allowed")
+	}
+
+	// Test that rate limiter respects the limit
+	count := 0
+	for i := 0; i < 150; i++ {
+		if rl.Allow(ctx) {
+			count++
+		}
+	}
+
+	// We started with 100 tokens and already used 1
+	// So we should have allowed 99 more
+	if count != 99 {
+		t.Errorf("Expected 99 more requests to be allowed, got %d", count)
+	}
+}
+
+func TestRateLimiterWithCancelledContext(t *testing.T) {
+	rl := NewRateLimiterSimple(100)
+	
+	// Create a cancelled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Should return false for cancelled context
+	allowed := rl.Allow(ctx)
+	if allowed {
+		t.Error("Should not allow with cancelled context")
+	}
+}
+
+func TestRateLimiterRefill(t *testing.T) {
+	rl := NewRateLimiterSimple(10)
+
+	// Use all tokens
+	ctx := context.Background()
+	for i := 0; i < 10; i++ {
+		rl.Allow(ctx)
+	}
+
+	// Should be rate limited now
+	if rl.Allow(ctx) {
+		t.Error("Should be rate limited after using all tokens")
+	}
+
+	// Wait for refill
+	time.Sleep(1100 * time.Millisecond)
+
+	// Should have new tokens
+	if !rl.Allow(ctx) {
+		t.Error("Should have tokens after refill")
+	}
+}


### PR DESCRIPTION
## Summary
- Update eBPF collector rate limiter to properly handle context for graceful shutdown
- Fix compilation issues with rate limiter initialization
- Add comprehensive tests for rate limiter functionality

## Changes
- Changed `NewRateLimiter(int64)` to `NewRateLimiterSimple(int64)` for proper initialization
- Updated `Allow()` method to `Allow(context)` to support context cancellation
- Added rate limiter tests covering basic functionality, context cancellation, and token refill

## Test Results
```bash
=== RUN   TestRateLimiterSimple
--- PASS: TestRateLimiterSimple (0.00s)
=== RUN   TestRateLimiterWithCancelledContext
--- PASS: TestRateLimiterWithCancelledContext (0.00s)
=== RUN   TestRateLimiterRefill
--- PASS: TestRateLimiterRefill (1.10s)
PASS
```

## Impact
This fix ensures the eBPF collector can properly shut down when the context is cancelled, preventing potential goroutine leaks and ensuring clean termination of the collector.

🤖 Generated with [Claude Code](https://claude.ai/code)