### PR TITLE
fix: add missing closing backticks to mermaid diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ flowchart TD
     DC --> NEO
     OC --> NEO
     PC --> NEO
+```
 
 ## Architecture Rules
 


### PR DESCRIPTION
## Summary
- Fixes the mermaid diagram rendering error on GitHub

## Problem
The mermaid code block was missing its closing backticks (```), causing GitHub to show:
`Parse error on line 43: Expecting 'SEMI', 'NEWLINE', 'EOF', 'AMP', 'START_LINK', 'LINK', 'LINK_ID', got 'NODE_STRING'`

## Solution
Added the missing closing backticks after line 78 (PC --> NEO)

## Test plan
- [x] Mermaid diagram now has proper closing backticks
- [x] Should render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.ai/code)