### PR TITLE
fix(cni): clean up CNI collector init.go formatting

### DIFF
--- a/pkg/collectors/cni/init.go
+++ b/pkg/collectors/cni/init.go
@@ -3,20 +3,15 @@ package cni
 import (
 	"log"
 
-  
 	"github.com/yairfalse/tapio/pkg/collectors/factory"
-
 )
 
 func init() {
 	// Register the CNI collector typed factory with error handling
-
 	factoryInstance := NewCNIFactory()
 	if err := factory.RegisterTypedFactory("cni", factoryInstance); err != nil {
-
 		// Log error but don't panic - this allows the application to continue
 		log.Printf("WARNING: failed to register CNI typed factory: %v", err)
 		log.Printf("CNI collector will not be available")
 	}
-
 }


### PR DESCRIPTION
## Summary
- Clean up formatting and imports in CNI collector init.go
- Remove extra whitespace and ensure proper alignment
- Maintain all existing functionality for factory registration

## Changes Made
- Fixed import formatting in `pkg/collectors/cni/init.go`
- Removed unnecessary blank lines and extra whitespace
- Ensured consistent code formatting per project standards

## Test Plan
- [x] CNI collector builds independently: `go build github.com/yairfalse/tapio/pkg/collectors/cni`
- [x] No functional changes - only formatting improvements
- [x] Factory registration still works properly

## Verification
This PR contains minimal, safe formatting changes to resolve conflicts and improve code quality. No logic changes were made.

🤖 Generated with [Claude Code](https://claude.ai/code)