### PR TITLE
fix(network-correlator): remove deprecated StartGoroutine call

### DIFF
--- a/pkg/collectors/network-correlator/collector_ebpf.go
+++ b/pkg/collectors/network-correlator/collector_ebpf.go
@@ -51,9 +51,11 @@ func (c *Collector) startPlatformSpecific(ctx context.Context) error {
 	}
 
 	// Start reading events
-	c.LifecycleManager.StartGoroutine("event-reader", func(ctx context.Context) error {
-		return c.readEvents(ctx)
-	})
+	go func() {
+		if err := c.readEvents(ctx); err != nil {
+			c.logger.Error("Event reader stopped", zap.Error(err))
+		}
+	}()
 
 	return nil
 }


### PR DESCRIPTION
Replace StartGoroutine with regular go routine in collector_ebpf.go event reader. The lifecycle manager already handles the main lifecycle, so individual goroutines should use regular go statement with proper context handling.

- Replace StartGoroutine with go func()
- Pass context from startPlatformSpecific to readEvents
- Maintain proper error logging for event reader

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description
<!-- Brief description of what this PR does -->

## Type of Change
<!-- Mark relevant items with an 'x' -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactoring
- [ ] 🚀 Performance improvement
- [ ] ✅ Test addition/update

## Checklist
<!-- Mark completed items with an 'x' -->
- [ ] My code follows the project's style guidelines
- [ ] I have run `gofmt -w .` to format my code
- [ ] I have run `go vet ./...` and addressed any issues
- [ ] I have run `go test ./...` and all tests pass
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) standard
- [ ] No stubs or TODOs in production code
- [ ] Architecture rules followed (5-level hierarchy)

## Testing
<!-- Describe how you tested your changes -->
- [ ] Unit tests pass (80%+ coverage)
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing completed

## Verification Results
```bash
# Paste output of:
$ gofmt -l . | grep -v vendor | wc -l
# Should be: 0

$ go build ./...
# Should show no errors

$ go test ./...
# Should show all tests passing
```

## Additional Context
<!-- Add any other context about the PR here -->

## Related Issues
<!-- Link any related issues here using #issue-number -->
Closes #