### PR TITLE
fix: add eBPF generation step to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang llvm libbpf-dev linux-headers-$(uname -r)
       
+      - name: Generate eBPF objects
+        run: |
+          for dir in pkg/observers/*/bpf; do
+            if [ -f "$dir/generate.go" ]; then
+              echo "Generating eBPF for $(basename $(dirname $dir))"
+              (cd "$dir" && go generate)
+            fi
+          done
+      
       - name: Build
         run: go build -v ./...
       


### PR DESCRIPTION
The CI was failing because eBPF .o files are not committed to the repo (following best practices like Cilium). Added a step to generate them during the build process using 'go generate' for each observer's BPF directory.

This ensures the build has all necessary eBPF objects without storing binary files in version control.

## Description
<!-- Brief description of what this PR does -->

## Type of Change
<!-- Mark relevant items with an 'x' -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactoring
- [ ] 🚀 Performance improvement
- [ ] ✅ Test addition/update

## Checklist
<!-- Mark completed items with an 'x' -->
- [ ] My code follows the project's style guidelines
- [ ] I have run `gofmt -w .` to format my code
- [ ] I have run `go vet ./...` and addressed any issues
- [ ] I have run `go test ./...` and all tests pass
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) standard
- [ ] No stubs or TODOs in production code
- [ ] Architecture rules followed (5-level hierarchy)

## Testing
<!-- Describe how you tested your changes -->
- [ ] Unit tests pass (80%+ coverage)
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing completed

## Verification Results
```bash
# Paste output of:
$ gofmt -l . | grep -v vendor | wc -l
# Should be: 0

$ go build ./...
# Should show no errors

$ go test ./...
# Should show all tests passing
```

## Additional Context
<!-- Add any other context about the PR here -->

## Related Issues
<!-- Link any related issues here using #issue-number -->
Closes #