### PR TITLE
fix(ebpf): CO-RE fallback for snd_cwnd rename in Linux 6.12+

### DIFF
--- a/ebpf/headers/tcp.h
+++ b/ebpf/headers/tcp.h
@@ -59,11 +59,32 @@ struct inet_connection_sock {
 //   - srtt_us:        trace_inet_sock_set_state (RTT tracking)
 //   - total_retrans:  trace_tcp_retransmit_skb (retransmit tracking)
 //   - snd_cwnd:       trace_tcp_retransmit_skb (congestion window)
+//
+// snd_cwnd was renamed to snd_cwnd_ in Linux 6.12 (made private with accessor).
+// We define both struct variants and use bpf_core_field_exists() to pick the right one.
 struct tcp_sock {
-	struct inet_connection_sock inet_conn;  // Parent struct (inheritance)
-	__u32 srtt_us;        // Smoothed RTT in microseconds (divided by 8)
-	__u32 total_retrans;  // Total retransmissions for this connection
-	__u32 snd_cwnd;       // Congestion window (packets)
+	struct inet_connection_sock inet_conn;
+	__u32 srtt_us;
+	__u32 total_retrans;
+	__u32 snd_cwnd;       // pre-6.12 kernels
 } __attribute__((preserve_access_index));
+
+struct tcp_sock_v612 {
+	struct inet_connection_sock inet_conn;
+	__u32 srtt_us;
+	__u32 total_retrans;
+	__u32 snd_cwnd_;      // 6.12+ kernels (renamed)
+} __attribute__((preserve_access_index));
+
+// Read snd_cwnd with CO-RE fallback for the 6.12+ rename.
+static __always_inline __u32 read_snd_cwnd(const void *sk) {
+	__u32 cwnd = 0;
+	if (bpf_core_field_exists(((struct tcp_sock *)0)->snd_cwnd)) {
+		bpf_core_read(&cwnd, sizeof(cwnd), &((struct tcp_sock *)sk)->snd_cwnd);
+	} else {
+		bpf_core_read(&cwnd, sizeof(cwnd), &((struct tcp_sock_v612 *)sk)->snd_cwnd_);
+	}
+	return cwnd;
+}
 
 #endif /* __TAPIO_TCP_H__ */

--- a/ebpf/network_monitor.c
+++ b/ebpf/network_monitor.c
@@ -441,11 +441,8 @@ read_tcp_sock:
 			}
 			evt->total_retrans = total_retrans > 65535 ? 65535 : (__u16)total_retrans;
 
-			__u32 snd_cwnd = 0;
-			if (bpf_core_read(&snd_cwnd, sizeof(snd_cwnd), &tp->snd_cwnd) != 0) {
-				bpf_ringbuf_discard(evt, 0);
-				return 0;
-			}
+			// snd_cwnd renamed to snd_cwnd_ in Linux 6.12 — CO-RE fallback
+			__u32 snd_cwnd = read_snd_cwnd(sk);
 			evt->snd_cwnd = snd_cwnd > 65535 ? 65535 : (__u16)snd_cwnd;
 		}
 	}


### PR DESCRIPTION
## Summary

**CRITICAL** — \`snd_cwnd\` was renamed to \`snd_cwnd_\` in Linux 6.12. CO-RE relocation fails silently, causing every retransmit event to be discarded on 6.12+ kernels (Fedora 41+, Ubuntu 25.04).

- Add \`tcp_sock_v612\` struct with \`snd_cwnd_\` field (\`preserve_access_index\`)
- Add \`read_snd_cwnd()\` helper using \`bpf_core_field_exists()\` to pick the correct field at load time
- Replace direct \`bpf_core_read(&snd_cwnd, ..., &tp->snd_cwnd)\` with the fallback helper
- Works on both pre-6.12 and 6.12+ kernels without recompilation

## Test plan

- [x] BPF compiles with clang 21
- [x] \`cargo test --workspace\` — 72 tests pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [ ] Verify retransmit events appear on Linux 6.12+ kernel

🤖 Generated with [Claude Code](https://claude.com/claude-code)