### PR TITLE
fix(ebpf): OOM events enrich from victim PID, not killer cgroup

### DIFF
--- a/ebpf/container_monitor.c
+++ b/ebpf/container_monitor.c
@@ -76,10 +76,11 @@ int handle_oom(struct trace_event_raw_mark_victim *ctx) {
 	evt->timestamp_ns = bpf_ktime_get_ns();
 	evt->type = EVENT_TYPE_OOM_KILL;
 
-	// Capture PID/TID from tracepoint
+	// ctx->pid is the VICTIM's PID (from tracepoint args).
+	// bpf_get_current_pid_tgid() returns the OOM KILLER's context, not the victim's.
+	// We emit the victim PID; userspace enriches via /proc/<pid>/cgroup.
 	evt->pid = ctx->pid;
-	__u64 pid_tgid = bpf_get_current_pid_tgid();
-	evt->tid = pid_tgid & 0xFFFFFFFF;
+	evt->tid = 0;  // victim TID not available from this tracepoint
 
 	// OOM kills always have exit code 137 (128 + SIGKILL=9)
 	evt->exit_code = 137;
@@ -94,9 +95,9 @@ int handle_oom(struct trace_event_raw_mark_victim *ctx) {
 	// Will be enriched by userspace from cgroupfs (if still available)
 	evt->memory_limit = 0;
 
-	// Capture cgroup ID - survives cgroup deletion (Issue #566)
-	// K8s pod context derived in Rust userspace using this ID
-	evt->cgroup_id = bpf_get_current_cgroup_id();
+	// cgroup_id from bpf_get_current_cgroup_id() is the OOM KILLER's cgroup,
+	// not the victim's. Set to 0 so userspace knows to enrich via victim PID instead.
+	evt->cgroup_id = 0;
 
 	bpf_ringbuf_submit(evt, 0);
 	return 0;

--- a/tapio-agent/src/observer/container.rs
+++ b/tapio-agent/src/observer/container.rs
@@ -303,13 +303,20 @@ pub async fn run(
                             let mut occ = build_occurrence(&event, &anomaly, boot_offset_ns);
                             if let Some(enricher) = enricher {
                                 let cgroup_id = event.cgroup_id;
-                                if cgroup_id != 0 {
-                                    enrich_total += 1;
-                                    if let Some(ctx) = enricher.enrich(cgroup_id) {
-                                        occ.context = Some(ctx);
-                                    } else {
-                                        enrich_miss += 1;
-                                    }
+                                let pid = event.pid;
+                                enrich_total += 1;
+                                let ctx = if cgroup_id != 0 {
+                                    // Normal path: enrich by cgroup_id (exit events)
+                                    enricher.enrich(cgroup_id)
+                                } else {
+                                    // OOM path: cgroup_id is 0 (BPF can't get victim's cgroup),
+                                    // enrich via /proc/<victim_pid>/cgroup instead
+                                    enricher.enrich_by_pid(pid)
+                                };
+                                if let Some(ctx) = ctx {
+                                    occ.context = Some(ctx);
+                                } else {
+                                    enrich_miss += 1;
                                 }
                             }
                             anomaly_count += 1;


### PR DESCRIPTION
## Summary

**HIGH** — In \`oom/mark_victim\`, \`bpf_get_current_cgroup_id()\` returns the OOM killer's cgroup, not the victim's. OOM occurrences were attributed to the wrong pod.

- BPF: set \`cgroup_id=0\` and \`tid=0\` for OOM events (killer context is unreliable)
- Rust: when \`cgroup_id==0\`, enrich via \`enrich_by_pid(victim_pid)\` using \`/proc/<pid>/cgroup\`
- Exit events unchanged — they still use the reliable \`cgroup_id\` path

## Test plan

- [x] BPF compiles with clang 21
- [x] \`cargo test --workspace\` — 72 tests pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)