### PR TITLE
fix(metrics): wire shutdown channel to metrics server

### DIFF
--- a/tapio-agent/src/main.rs
+++ b/tapio-agent/src/main.rs
@@ -187,23 +187,19 @@ async fn main() -> anyhow::Result<()> {
             tapio_metrics.k8s_reflector_up.set(1);
         }
 
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
         // Start Prometheus metrics server if enabled
         if cfg.metrics.enabled {
             let registry = tapio_metrics.registry.clone();
             let metrics_port = cfg.metrics.port;
-            // shutdown_rx will be created below — metrics server gets its own clone
-            let (metrics_shutdown_tx, metrics_shutdown_rx) = tokio::sync::watch::channel(false);
+            let metrics_shutdown_rx = shutdown_rx.clone();
             tokio::spawn(async move {
                 if let Err(e) = metrics::serve(registry, metrics_port, metrics_shutdown_rx).await {
                     tracing::error!(error = %e, "metrics server failed");
                 }
             });
-            // Wire metrics shutdown into main shutdown below
-            // (kept simple: metrics server stopped by dropping its receiver)
-            let _ = metrics_shutdown_tx;
         }
-
-        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
         tokio::spawn(async move {
             tokio::signal::ctrl_c().await.ok();


### PR DESCRIPTION
## Summary

**HIGH** — \`metrics_shutdown_tx\` was dropped immediately after creation (\`let _ = metrics_shutdown_tx\`), causing the metrics server to shut down before serving any requests.

Fix: create the main shutdown channel first, then clone \`shutdown_rx\` for the metrics server. The metrics endpoint now lives until SIGINT, same as the observers.

## Test plan

- [x] \`cargo test --workspace\` — 72 tests pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)