### PR TITLE
fix(metrics): wire TapioMetrics to all observer loops

### DIFF
--- a/tapio-agent/src/main.rs
+++ b/tapio-agent/src/main.rs
@@ -224,6 +224,7 @@ async fn main() -> anyhow::Result<()> {
 
         let sink1: Arc<dyn tapio_common::sink::Sink> = multi_sink.clone();
         let enricher1 = enricher.clone();
+        let metrics1 = tapio_metrics.clone();
         let rx1 = shutdown_rx.clone();
         let dir1 = ebpf_dir.clone();
         let net = tokio::spawn(async move {
@@ -234,6 +235,7 @@ async fn main() -> anyhow::Result<()> {
                 enricher1.as_deref(),
                 boot_offset_ns,
                 net_thresholds,
+                &metrics1,
                 rx1,
             )
             .await
@@ -244,6 +246,7 @@ async fn main() -> anyhow::Result<()> {
 
         let sink2: Arc<dyn tapio_common::sink::Sink> = multi_sink.clone();
         let enricher2 = enricher.clone();
+        let metrics2 = tapio_metrics.clone();
         let rx2 = shutdown_rx.clone();
         let dir2 = ebpf_dir.clone();
         let ctr = tokio::spawn(async move {
@@ -253,6 +256,7 @@ async fn main() -> anyhow::Result<()> {
                 sink2.as_ref(),
                 enricher2.as_deref(),
                 boot_offset_ns,
+                &metrics2,
                 rx2,
             )
             .await
@@ -263,6 +267,7 @@ async fn main() -> anyhow::Result<()> {
 
         let sink3: Arc<dyn tapio_common::sink::Sink> = multi_sink.clone();
         let enricher3 = enricher.clone();
+        let metrics3 = tapio_metrics.clone();
         let rx3 = shutdown_rx.clone();
         let dir3 = ebpf_dir.clone();
         let stg = tokio::spawn(async move {
@@ -273,6 +278,7 @@ async fn main() -> anyhow::Result<()> {
                 enricher3.as_deref(),
                 boot_offset_ns,
                 stg_thresholds,
+                &metrics3,
                 rx3,
             )
             .await
@@ -288,12 +294,13 @@ async fn main() -> anyhow::Result<()> {
         };
 
         let sink4: Arc<dyn tapio_common::sink::Sink> = multi_sink.clone();
+        let metrics4 = tapio_metrics.clone();
         let rx4 = shutdown_rx.clone();
         let dir4 = ebpf_dir.clone();
         let pmc = tokio::spawn(async move {
             let path = format!("{dir4}/node_pmc_monitor.o");
             if let Err(e) =
-                observer::node_pmc::run(&path, sink4.as_ref(), boot_offset_ns, pmc_thresholds, rx4)
+                observer::node_pmc::run(&path, sink4.as_ref(), boot_offset_ns, pmc_thresholds, &metrics4, rx4)
                     .await
             {
                 tracing::error!(error = %e, "PMC observer failed");

--- a/tapio-agent/src/observer/container.rs
+++ b/tapio-agent/src/observer/container.rs
@@ -215,6 +215,7 @@ pub async fn run(
     sink: &dyn tapio_common::sink::Sink,
     enricher: Option<&crate::enricher::K8sEnricher>,
     boot_offset_ns: u64,
+    metrics: &crate::metrics::TapioMetrics,
     mut shutdown: tokio::sync::watch::Receiver<bool>,
 ) -> anyhow::Result<()> {
     use aya::{Ebpf, maps::RingBuf, programs::TracePoint};
@@ -299,6 +300,7 @@ pub async fn run(
                             std::ptr::read_unaligned(data.as_ptr() as *const ContainerEvent)
                         };
                         event_count += 1;
+                        metrics.events_total.with_label_values(&["container"]).inc();
                         if let Some(anomaly) = classify(&event) {
                             let mut occ = build_occurrence(&event, &anomaly, boot_offset_ns);
                             if let Some(enricher) = enricher {
@@ -309,10 +311,12 @@ pub async fn run(
                                         occ.context = Some(ctx);
                                     } else {
                                         enrich_miss += 1;
+                                        metrics.enrichment_miss_total.with_label_values(&["container"]).inc();
                                     }
                                 }
                             }
                             anomaly_count += 1;
+                            metrics.anomalies_total.with_label_values(&["container", anomaly.event_type]).inc();
                             if let Err(e) = sink.send(&occ) {
                                 tracing::warn!(error = %e, "sink error");
                             }
@@ -323,6 +327,7 @@ pub async fn run(
                     count
                 });
                 if drained >= super::MAX_DRAIN_PER_TICK {
+                    metrics.drain_cap_total.with_label_values(&["container"]).inc();
                     tracing::warn!(observer = "container", drained, "ring buffer drain capped");
                 }
             }

--- a/tapio-agent/src/observer/network.rs
+++ b/tapio-agent/src/observer/network.rs
@@ -161,6 +161,7 @@ pub async fn run(
     enricher: Option<&crate::enricher::K8sEnricher>,
     _boot_offset_ns: u64,
     thresholds: NetworkThresholds,
+    metrics: &crate::metrics::TapioMetrics,
     mut shutdown: tokio::sync::watch::Receiver<bool>,
 ) -> anyhow::Result<()> {
     use aya::{Ebpf, maps::RingBuf, programs::TracePoint};
@@ -258,6 +259,7 @@ pub async fn run(
                             std::ptr::read_unaligned(data.as_ptr() as *const NetworkEvent)
                         };
                         event_count += 1;
+                        metrics.events_total.with_label_values(&["network"]).inc();
                         if let Some(anomaly) = classify(&event) {
                             let mut occ = build_occurrence(&event, &anomaly);
                             if let Some(enricher) = enricher {
@@ -267,9 +269,11 @@ pub async fn run(
                                     occ.context = Some(ctx);
                                 } else {
                                     enrich_miss += 1;
+                                    metrics.enrichment_miss_total.with_label_values(&["network"]).inc();
                                 }
                             }
                             anomaly_count += 1;
+                            metrics.anomalies_total.with_label_values(&["network", anomaly.event_type]).inc();
                             if let Err(e) = sink.send(&occ) {
                                 tracing::warn!(error = %e, "sink error");
                             }
@@ -280,6 +284,7 @@ pub async fn run(
                     count
                 });
                 if drained >= super::MAX_DRAIN_PER_TICK {
+                    metrics.drain_cap_total.with_label_values(&["network"]).inc();
                     tracing::warn!(observer = "network", drained, "ring buffer drain capped");
                 }
             }

--- a/tapio-agent/src/observer/node_pmc.rs
+++ b/tapio-agent/src/observer/node_pmc.rs
@@ -238,6 +238,7 @@ pub async fn run(
     sink: &dyn tapio_common::sink::Sink,
     boot_offset_ns: u64,
     thresholds: PmcThresholds,
+    metrics: &crate::metrics::TapioMetrics,
     mut shutdown: tokio::sync::watch::Receiver<bool>,
 ) -> anyhow::Result<()> {
     use aya::Ebpf;
@@ -356,9 +357,11 @@ pub async fn run(
                             std::ptr::read_unaligned(data.as_ptr() as *const PmcEvent)
                         };
                         event_count += 1;
+                        metrics.events_total.with_label_values(&["node_pmc"]).inc();
                         if let Some(anomaly) = classify(&event, &thresholds) {
                             let occ = build_occurrence(&event, &anomaly, boot_offset_ns);
                             anomaly_count += 1;
+                            metrics.anomalies_total.with_label_values(&["node_pmc", anomaly.event_type]).inc();
                             if let Err(e) = sink.send(&occ) {
                                 tracing::warn!(error = %e, "sink error");
                             }
@@ -369,6 +372,7 @@ pub async fn run(
                     count
                 });
                 if drained >= super::MAX_DRAIN_PER_TICK {
+                    metrics.drain_cap_total.with_label_values(&["node_pmc"]).inc();
                     tracing::warn!(observer = "pmc", drained, "ring buffer drain capped");
                 }
             }

--- a/tapio-agent/src/observer/node_pmc.rs
+++ b/tapio-agent/src/observer/node_pmc.rs
@@ -336,7 +336,7 @@ pub async fn run(
                     let lost = super::read_percpu_sum(fd, super::METRIC_LOST_EVENTS, num_cpus as usize);
                     if lost > prev_lost {
                         tracing::warn!(
-                            observer = "pmc",
+                            observer = "node_pmc",
                             lost_total = lost,
                             lost_delta = lost - prev_lost,
                             "ring buffer events lost"
@@ -373,7 +373,7 @@ pub async fn run(
                 });
                 if drained >= super::MAX_DRAIN_PER_TICK {
                     metrics.drain_cap_total.with_label_values(&["node_pmc"]).inc();
-                    tracing::warn!(observer = "pmc", drained, "ring buffer drain capped");
+                    tracing::warn!(observer = "node_pmc", drained, "ring buffer drain capped");
                 }
             }
         }

--- a/tapio-agent/src/observer/storage.rs
+++ b/tapio-agent/src/observer/storage.rs
@@ -87,6 +87,7 @@ pub async fn run(
     enricher: Option<&crate::enricher::K8sEnricher>,
     boot_offset_ns: u64,
     thresholds: StorageThresholds,
+    metrics: &crate::metrics::TapioMetrics,
     mut shutdown: tokio::sync::watch::Receiver<bool>,
 ) -> anyhow::Result<()> {
     use aya::{Ebpf, maps::RingBuf, programs::TracePoint};
@@ -183,6 +184,7 @@ pub async fn run(
                             std::ptr::read_unaligned(data.as_ptr() as *const StorageEvent)
                         };
                         event_count += 1;
+                        metrics.events_total.with_label_values(&["storage"]).inc();
                         if let Some(anomaly) = classify(&event) {
                             let mut occ = build_occurrence(&event, &anomaly, boot_offset_ns);
                             if let Some(enricher) = enricher {
@@ -193,10 +195,12 @@ pub async fn run(
                                         occ.context = Some(ctx);
                                     } else {
                                         enrich_miss += 1;
+                                        metrics.enrichment_miss_total.with_label_values(&["storage"]).inc();
                                     }
                                 }
                             }
                             anomaly_count += 1;
+                            metrics.anomalies_total.with_label_values(&["storage", anomaly.event_type]).inc();
                             if let Err(e) = sink.send(&occ) {
                                 tracing::warn!(error = %e, "sink error");
                             }
@@ -207,6 +211,7 @@ pub async fn run(
                     count
                 });
                 if drained >= super::MAX_DRAIN_PER_TICK {
+                    metrics.drain_cap_total.with_label_values(&["storage"]).inc();
                     tracing::warn!(observer = "storage", drained, "ring buffer drain capped");
                 }
             }


### PR DESCRIPTION
## Summary

**HIGH** — TapioMetrics was created but never passed to observers. Prometheus counters were always zero.

- Add \`metrics: &TapioMetrics\` parameter to all 4 observer \`run()\` functions
- Increment \`events_total\`, \`anomalies_total\`, \`enrichment_miss_total\`, \`drain_cap_total\` at the right points in each event loop
- Clone metrics for each spawned observer task in \`main.rs\`

## Test plan

- [x] \`cargo test --workspace\` — 72 tests pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)