### PR TITLE
fix(polku): release mutex before blocking HTTP I/O

### DIFF
--- a/tapio-agent/src/sink/polku.rs
+++ b/tapio-agent/src/sink/polku.rs
@@ -6,16 +6,16 @@ use tapio_common::sink::{Sink, SinkError};
 
 /// Sink that batches occurrences and POSTs them to POLKU's HTTP ingest endpoint.
 /// Buffers events and flushes when buffer_size is reached or flush_interval elapses.
-/// On send failure, retains the buffer for retry with exponential backoff.
+/// On send failure, batch is lost (logged). Exponential backoff prevents tight retry loops.
 /// If the buffer exceeds 10x buffer_size, drops oldest events.
 pub struct PolkuSink {
+    endpoint: String,
+    buffer_size: usize,
     inner: Mutex<PolkuInner>,
 }
 
 struct PolkuInner {
-    endpoint: String,
     buffer: Vec<Occurrence>,
-    buffer_size: usize,
     flush_interval: Duration,
     last_flush: Instant,
     next_retry: Instant,
@@ -30,10 +30,10 @@ impl PolkuSink {
     pub fn new(endpoint: &str, buffer_size: usize, flush_interval: Duration) -> Self {
         let now = Instant::now();
         Self {
+            endpoint: endpoint.to_string(),
+            buffer_size,
             inner: Mutex::new(PolkuInner {
-                endpoint: endpoint.to_string(),
                 buffer: Vec::with_capacity(buffer_size),
-                buffer_size,
                 flush_interval,
                 last_flush: now,
                 next_retry: now,
@@ -46,41 +46,62 @@ impl PolkuSink {
 
 impl Sink for PolkuSink {
     fn send(&self, occurrence: &Occurrence) -> Result<(), SinkError> {
-        let mut inner = self
-            .inner
-            .lock()
-            .map_err(|e| SinkError::Send(e.to_string()))?;
+        let batch = {
+            let mut inner = self
+                .inner
+                .lock()
+                .map_err(|e| SinkError::Send(e.to_string()))?;
 
-        // Backpressure: drop oldest events if buffer exceeds max
-        if inner.buffer.len() >= inner.max_buffer {
-            let drain_count = inner.buffer.len() - inner.buffer_size;
-            inner.buffer.drain(..drain_count);
-            tracing::warn!(
-                dropped = drain_count,
-                "polku sink buffer overflow, dropped oldest events"
-            );
-        }
+            // Backpressure: drop oldest events if buffer exceeds max
+            if inner.buffer.len() >= inner.max_buffer {
+                let drain_count = inner.buffer.len() - self.buffer_size;
+                inner.buffer.drain(..drain_count);
+                tracing::warn!(
+                    dropped = drain_count,
+                    "polku sink buffer overflow, dropped oldest events"
+                );
+            }
 
-        inner.buffer.push(occurrence.clone());
+            inner.buffer.push(occurrence.clone());
 
-        // Flush if buffer is full or interval elapsed (respecting backoff)
-        let now = Instant::now();
-        if now >= inner.next_retry
-            && (inner.buffer.len() >= inner.buffer_size
-                || inner.last_flush.elapsed() >= inner.flush_interval)
-        {
-            flush_inner(&mut inner);
+            // Check if we should flush (respecting backoff)
+            let now = Instant::now();
+            let should_flush = now >= inner.next_retry
+                && (inner.buffer.len() >= self.buffer_size
+                    || inner.last_flush.elapsed() >= inner.flush_interval);
+
+            if should_flush {
+                // Take the buffer out — lock released when this block ends
+                let batch: Vec<Occurrence> = inner.buffer.drain(..).collect();
+                inner.last_flush = now;
+                Some(batch)
+            } else {
+                None
+            }
+        }; // lock released here — before any I/O
+
+        if let Some(batch) = batch {
+            self.post_batch(batch);
         }
 
         Ok(())
     }
 
     fn flush(&self) -> Result<(), SinkError> {
-        let mut inner = self
-            .inner
-            .lock()
-            .map_err(|e| SinkError::Send(e.to_string()))?;
-        flush_inner(&mut inner);
+        let batch = {
+            let mut inner = self
+                .inner
+                .lock()
+                .map_err(|e| SinkError::Send(e.to_string()))?;
+            if inner.buffer.is_empty() {
+                return Ok(());
+            }
+            let batch: Vec<Occurrence> = inner.buffer.drain(..).collect();
+            inner.last_flush = Instant::now();
+            batch
+        }; // lock released here
+
+        self.post_batch(batch);
         Ok(())
     }
 
@@ -89,51 +110,49 @@ impl Sink for PolkuSink {
     }
 }
 
-fn flush_inner(inner: &mut PolkuInner) {
-    if inner.buffer.is_empty() {
-        return;
-    }
-
-    let payload = match serde_json::to_vec(&inner.buffer) {
-        Ok(p) => p,
-        Err(e) => {
-            tracing::warn!(error = %e, "polku sink: failed to serialize batch");
+impl PolkuSink {
+    /// POST batch to endpoint. On failure, batch is lost (logged + backoff updated).
+    fn post_batch(&self, batch: Vec<Occurrence>) {
+        if batch.is_empty() {
             return;
         }
-    };
 
-    // Release mutex before blocking I/O by extracting what we need
-    let endpoint = inner.endpoint.clone();
+        let payload = match serde_json::to_vec(&batch) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!(error = %e, "polku sink: failed to serialize batch");
+                return;
+            }
+        };
 
-    match post_json(&endpoint, &payload) {
-        Ok(()) => {
-            tracing::debug!(count = inner.buffer.len(), "polku sink: batch sent");
-            inner.buffer.clear();
-            inner.last_flush = Instant::now();
-            inner.backoff = INITIAL_BACKOFF;
-        }
-        Err(e) => {
-            // Exponential backoff: don't retry on every send() during outages
-            let now = Instant::now();
-            inner.next_retry = now + inner.backoff;
-            inner.backoff = (inner.backoff * 2).min(MAX_BACKOFF);
-            tracing::warn!(
-                error = %e,
-                buffered = inner.buffer.len(),
-                retry_in_secs = inner.backoff.as_secs(),
-                "polku sink: send failed, backing off"
-            );
+        match post_json(&self.endpoint, &payload) {
+            Ok(()) => {
+                tracing::debug!(count = batch.len(), "polku sink: batch sent");
+                if let Ok(mut inner) = self.inner.lock() {
+                    inner.backoff = INITIAL_BACKOFF;
+                }
+            }
+            Err(e) => {
+                if let Ok(mut inner) = self.inner.lock() {
+                    let now = Instant::now();
+                    inner.next_retry = now + inner.backoff;
+                    inner.backoff = (inner.backoff * 2).min(MAX_BACKOFF);
+                }
+                tracing::warn!(
+                    error = %e,
+                    dropped = batch.len(),
+                    "polku sink: send failed, batch dropped"
+                );
+            }
         }
     }
 }
 
 /// Minimal HTTP POST using std::net::TcpStream.
-/// Avoids adding reqwest/hyper as dependencies.
 fn post_json(endpoint: &str, body: &[u8]) -> Result<(), String> {
     use std::io::{Read, Write};
     use std::net::TcpStream;
 
-    // Parse endpoint: http://host:port/path
     let url = endpoint
         .strip_prefix("http://")
         .ok_or_else(|| format!("endpoint must start with http://: {endpoint}"))?;
@@ -160,7 +179,6 @@ fn post_json(endpoint: &str, body: &[u8]) -> Result<(), String> {
         .write_all(body)
         .map_err(|e| format!("write body: {e}"))?;
 
-    // Read response status line
     let mut response = [0u8; 256];
     let n = stream
         .read(&mut response)


### PR DESCRIPTION
## Summary

**HIGH** — PolkuSink held the Mutex across \`post_json()\` (5s TCP timeout), stalling all 4 observers during flushes.

- \`send()\`: takes buffer out under lock, releases lock, then POSTs with owned data
- \`flush()\`: same pattern — drain buffer, drop lock, then POST
- On failure: batch is dropped (logged), backoff state updated via brief re-lock
- \`send()\` returns immediately even when a flush is in progress on another thread

## Test plan

- [x] \`cargo test --workspace\` — 72 tests pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)