### PR TITLE
fix(mcp): handle id:null as request per JSON-RPC 2.0

### DIFF
--- a/tapio-cli/src/main.rs
+++ b/tapio-cli/src/main.rs
@@ -366,17 +366,18 @@ async fn cmd_mcp(data_dir: &Path) -> anyhow::Result<()> {
             }
         };
 
+        // JSON-RPC 2.0: missing "id" field = notification (no response).
+        // Present "id" field (even if null) = request (must respond).
+        let has_id = request.get("id").is_some();
         let id = request.get("id").cloned();
-        let is_notification = id.is_none() || id.as_ref().is_some_and(|v| v.is_null());
         let method = request.get("method").and_then(|m| m.as_str()).unwrap_or("");
         let params = request
             .get("params")
             .cloned()
             .unwrap_or(serde_json::json!({}));
 
-        // JSON-RPC: notifications (no id) get no response
-        if is_notification {
-            continue;
+        if !has_id {
+            continue; // notification — no response
         }
 
         match method {


### PR DESCRIPTION
**HIGH** — \`id: null\` was treated as notification and silently dropped. Per JSON-RPC 2.0, missing \`id\` = notification, present \`id\` (even null) = request that must get a response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)