### PR TITLE
fix(ebpf): zero storage event padding to prevent kernel stack leak

### DIFF
--- a/ebpf/storage_monitor.c
+++ b/ebpf/storage_monitor.c
@@ -171,6 +171,9 @@ int trace_block_rq_complete(struct trace_event_raw_block_rq_completion *ctx) {
 		return 0;
 	}
 
+	// Zero-init before filling — prevents leaking kernel stack via padding bytes
+	__builtin_memset(evt, 0, sizeof(*evt));
+
 	// Fill event
 	evt->timestamp_ns = now_ns;
 	evt->latency_ns = latency_ns;


### PR DESCRIPTION
**MEDIUM** — 4 bytes of kernel stack leaked per storage event. Added memset after ringbuf reserve, consistent with other observers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)