### PR TITLE
fix(cli): reject negative and zero durations

### DIFF
--- a/tapio-cli/src/main.rs
+++ b/tapio-cli/src/main.rs
@@ -664,6 +664,9 @@ fn parse_duration(s: &str) -> anyhow::Result<chrono::Duration> {
     let num: i64 = num_str
         .parse()
         .map_err(|_| anyhow::anyhow!("invalid duration number: {num_str}"))?;
+    if num <= 0 {
+        anyhow::bail!("duration must be positive (e.g. 5m, 1h)");
+    }
     match unit {
         "s" => Ok(chrono::Duration::seconds(num)),
         "m" => Ok(chrono::Duration::minutes(num)),
@@ -700,6 +703,8 @@ mod tests {
         assert!(parse_duration("abc").is_err());
         assert!(parse_duration("5x").is_err());
         assert!(parse_duration("").is_err());
+        assert!(parse_duration("-5m").is_err());
+        assert!(parse_duration("0s").is_err());
     }
 
     #[test]

--- a/tapio-cli/src/main.rs
+++ b/tapio-cli/src/main.rs
@@ -665,7 +665,7 @@ fn parse_duration(s: &str) -> anyhow::Result<chrono::Duration> {
         .parse()
         .map_err(|_| anyhow::anyhow!("invalid duration number: {num_str}"))?;
     if num <= 0 {
-        anyhow::bail!("duration must be positive (e.g. 5m, 1h)");
+        anyhow::bail!("duration must be positive: {s}");
     }
     match unit {
         "s" => Ok(chrono::Duration::seconds(num)),


### PR DESCRIPTION
**MEDIUM** — `--since -5m` silently returned empty results. Now rejects non-positive values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)