### PR TITLE
fix(security): metrics server defaults to localhost

### DIFF
--- a/tapio-agent/src/config.rs
+++ b/tapio-agent/src/config.rs
@@ -55,6 +55,9 @@ impl Default for Thresholds {
 pub struct Metrics {
     pub enabled: bool,
     pub port: u16,
+    /// Bind address for /metrics endpoint. Default 127.0.0.1 (localhost only).
+    /// Set to "0.0.0.0" to expose to the node network.
+    pub bind_address: String,
 }
 
 impl Default for Metrics {
@@ -62,6 +65,7 @@ impl Default for Metrics {
         Self {
             enabled: false,
             port: 9090,
+            bind_address: "127.0.0.1".into(),
         }
     }
 }

--- a/tapio-agent/src/config.rs
+++ b/tapio-agent/src/config.rs
@@ -155,4 +155,27 @@ mod tests {
         assert!(config.metrics.enabled);
         assert_eq!(config.metrics.port, 8080);
     }
+
+    #[test]
+    fn metrics_default_bind_address_is_valid_ip() {
+        let config = Config::default();
+        let ip: std::net::IpAddr = config.metrics.bind_address.parse().unwrap();
+        assert!(ip.is_loopback());
+    }
+
+    #[test]
+    fn metrics_bind_address_ipv6() {
+        let config: Config = toml::from_str(
+            r#"
+            [metrics]
+            enabled = true
+            bind_address = "::1"
+            "#,
+        )
+        .unwrap();
+        let ip: std::net::IpAddr = config.metrics.bind_address.parse().unwrap();
+        assert!(ip.is_loopback());
+        let addr = std::net::SocketAddr::new(ip, config.metrics.port);
+        assert_eq!(addr.to_string(), "[::1]:9090");
+    }
 }

--- a/tapio-agent/src/enricher.rs
+++ b/tapio-agent/src/enricher.rs
@@ -37,8 +37,9 @@ impl K8sEnricher {
                     Ok(watcher::Event::Delete(pod)) => {
                         if let Some(uid) = pod.metadata.uid.as_deref() {
                             let uid_owned = uid.to_string();
-                            cache_for_reflector
-                                .retain(|_: &u64, v: &mut Option<String>| v.as_deref() != Some(uid_owned.as_str()));
+                            cache_for_reflector.retain(|_: &u64, v: &mut Option<String>| {
+                                v.as_deref() != Some(uid_owned.as_str())
+                            });
                             tracing::debug!(pod_uid = uid, "cleaned stale cgroup cache entries");
                         }
                     }

--- a/tapio-agent/src/main.rs
+++ b/tapio-agent/src/main.rs
@@ -190,11 +190,14 @@ async fn main() -> anyhow::Result<()> {
         // Start Prometheus metrics server if enabled
         if cfg.metrics.enabled {
             let registry = tapio_metrics.registry.clone();
-            let metrics_port = cfg.metrics.port;
+            let metrics_addr: std::net::SocketAddr =
+                format!("{}:{}", cfg.metrics.bind_address, cfg.metrics.port)
+                    .parse()
+                    .map_err(|e| anyhow::anyhow!("invalid metrics bind address: {e}"))?;
             // shutdown_rx will be created below — metrics server gets its own clone
             let (metrics_shutdown_tx, metrics_shutdown_rx) = tokio::sync::watch::channel(false);
             tokio::spawn(async move {
-                if let Err(e) = metrics::serve(registry, metrics_port, metrics_shutdown_rx).await {
+                if let Err(e) = metrics::serve(registry, metrics_addr, metrics_shutdown_rx).await {
                     tracing::error!(error = %e, "metrics server failed");
                 }
             });

--- a/tapio-agent/src/main.rs
+++ b/tapio-agent/src/main.rs
@@ -190,10 +190,12 @@ async fn main() -> anyhow::Result<()> {
         // Start Prometheus metrics server if enabled
         if cfg.metrics.enabled {
             let registry = tapio_metrics.registry.clone();
-            let metrics_addr: std::net::SocketAddr =
-                format!("{}:{}", cfg.metrics.bind_address, cfg.metrics.port)
-                    .parse()
-                    .map_err(|e| anyhow::anyhow!("invalid metrics bind address: {e}"))?;
+            let metrics_ip: std::net::IpAddr = cfg
+                .metrics
+                .bind_address
+                .parse()
+                .map_err(|e| anyhow::anyhow!("invalid metrics bind_address: {e}"))?;
+            let metrics_addr = std::net::SocketAddr::new(metrics_ip, cfg.metrics.port);
             // shutdown_rx will be created below — metrics server gets its own clone
             let (metrics_shutdown_tx, metrics_shutdown_rx) = tokio::sync::watch::channel(false);
             tokio::spawn(async move {

--- a/tapio-agent/src/metrics.rs
+++ b/tapio-agent/src/metrics.rs
@@ -130,11 +130,11 @@ impl TapioMetrics {
     }
 }
 
-/// Serve /metrics on the given port. Runs until the shutdown token is cancelled.
+/// Serve /metrics on the given address. Runs until the shutdown token is cancelled.
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub async fn serve(
     registry: Arc<Registry>,
-    port: u16,
+    addr: SocketAddr,
     mut shutdown: tokio::sync::watch::Receiver<bool>,
 ) -> anyhow::Result<()> {
     use axum::{Router, http::header, routing::get};
@@ -163,7 +163,6 @@ pub async fn serve(
         }),
     );
 
-    let addr = SocketAddr::from(([0, 0, 0, 0], port));
     tracing::info!(%addr, "prometheus metrics endpoint starting");
 
     let listener = tokio::net::TcpListener::bind(addr).await?;

--- a/tapio-agent/src/metrics.rs
+++ b/tapio-agent/src/metrics.rs
@@ -130,7 +130,7 @@ impl TapioMetrics {
     }
 }
 
-/// Serve /metrics on the given address. Runs until the shutdown token is cancelled.
+/// Serve /metrics on the given address. Runs until the shutdown signal is received.
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub async fn serve(
     registry: Arc<Registry>,


### PR DESCRIPTION
**MEDIUM** — Prometheus endpoint was on 0.0.0.0. Now 127.0.0.1 by default, configurable via `metrics.bind_address`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)