### PR TITLE
fix(security): set PR_SET_NO_NEW_PRIVS at startup

### DIFF
--- a/tapio-agent/src/main.rs
+++ b/tapio-agent/src/main.rs
@@ -128,6 +128,9 @@ async fn main() -> anyhow::Result<()> {
     #[cfg(target_os = "linux")]
     unsafe {
         libc::signal(libc::SIGPIPE, libc::SIG_IGN);
+        // Prevent the process from gaining new privileges (e.g., via execve of
+        // setuid binaries). Reduces blast radius if the agent is compromised.
+        libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
     }
 
     // Use a non-panicking writer for tracing — default stderr writer panics


### PR DESCRIPTION
**MEDIUM** — Prevents privilege escalation via execve. Full cap drop after BPF load deferred (needs startup refactor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)