### PR TITLE
fix(ebpf): check bpf_core_read return for task->exit_code

### DIFF
--- a/ebpf/container_monitor.c
+++ b/ebpf/container_monitor.c
@@ -131,7 +131,8 @@ int handle_exit(struct trace_event_raw_sched_process_exit *ctx) {
 	// Read exit_code from task_struct (CO-RE: field offset resolved at load time via BTF)
 	// exit_code format: (exit_code << 8) | signal
 	__u32 exit_code = 0;
-	bpf_core_read(&exit_code, sizeof(exit_code), &task->exit_code);
+	if (bpf_core_read(&exit_code, sizeof(exit_code), &task->exit_code) != 0)
+		return 0;
 
 	__s32 code = exit_code >> 8;
 	__s32 sig = exit_code & 0x7F;


### PR DESCRIPTION
## Summary
- Check the return value when reading task->exit_code in the container observer.
- Return early when the CO-RE read fails instead of processing the zero initializer.

## Why
A failed task->exit_code read left exit_code at zero, making the BPF-side clean-exit filter silently drop the event as if the process exited normally.

## Test plan
- [ ] cargo check --workspace passes
- [ ] eBPF program still compiles with: clang -O2 -g -target bpf -D__TARGET_ARCH_x86 -I ebpf/headers -c ebpf/container_monitor.c -o /tmp/out.o
- [ ] failed task->exit_code reads are no longer indistinguishable from clean exits