### PR TITLE
fix(ebpf): zero-init container and pmc events for defense-in-depth

### DIFF
--- a/ebpf/container_monitor.c
+++ b/ebpf/container_monitor.c
@@ -71,6 +71,7 @@ int handle_oom(struct trace_event_raw_mark_victim *ctx) {
 		metric_inc(METRIC_LOST_EVENTS);
 		return 0;
 	}
+	__builtin_memset(evt, 0, sizeof(*evt));
 
 	// Capture timestamp and event type
 	evt->timestamp_ns = bpf_ktime_get_ns();
@@ -147,6 +148,7 @@ int handle_exit(struct trace_event_raw_sched_process_exit *ctx) {
 		metric_inc(METRIC_LOST_EVENTS);
 		return 0;
 	}
+	__builtin_memset(evt, 0, sizeof(*evt));
 
 	// Capture timestamp and event type
 	evt->timestamp_ns = bpf_ktime_get_ns();

--- a/ebpf/node_pmc_monitor.c
+++ b/ebpf/node_pmc_monitor.c
@@ -69,6 +69,7 @@ int sample_pmc(struct bpf_perf_event_data *ctx)
 		metric_inc(METRIC_LOST_EVENTS);
 		return 0;
 	}
+	__builtin_memset(event, 0, sizeof(*event));
 
 	// Read PMC counter values via bpf_perf_event_read_value
 	__s64 cycles = read_pmc(&pmc_cycles, cpu);


### PR DESCRIPTION
## Summary
- Zero container OOM events immediately after successful ringbuf reservation.
- Zero container exit events immediately after successful ringbuf reservation.
- Zero PMC sample events immediately after successful ringbuf reservation.

## Why
These event structs are currently packed, but zeroing reserved ring-buffer events matches the other observers and prevents future padding additions from leaking kernel stack bytes.

## Test plan
- [ ] cargo check --workspace passes
- [ ] eBPF programs still compile with: clang -O2 -g -target bpf -D__TARGET_ARCH_x86 -I ebpf/headers -c ebpf/container_monitor.c -o /tmp/container_monitor.o and clang -O2 -g -target bpf -D__TARGET_ARCH_x86 -I ebpf/headers -c ebpf/node_pmc_monitor.c -o /tmp/node_pmc_monitor.o
- [ ] each container and PMC ringbuf reservation path zeroes the event before filling fields