### PR TITLE
fix(ebpf): widen storage error_code to signed 32-bit

### DIFF
--- a/ebpf/storage_monitor.c
+++ b/ebpf/storage_monitor.c
@@ -34,11 +34,11 @@ struct storage_event {
 	__u32 dev_minor;      // offset 36
 	__u32 bytes;          // offset 40
 	__u32 pid;            // offset 44
-	__u16 error_code;     // offset 48
-	__u8  opcode;         // offset 50
-	__u8  severity;       // offset 51
-	__u8  comm[16];       // offset 52
-	__u8  _pad[4];        // offset 68, explicit padding to 72 bytes
+	__s32 error_code;     // offset 48
+	__u8  opcode;         // offset 52
+	__u8  severity;       // offset 53
+	__u8  comm[16];       // offset 54
+	__u8  _pad[2];        // offset 70, explicit padding to 72 bytes
 };
 
 // Key for tracking inflight I/O operations
@@ -130,7 +130,7 @@ int trace_block_rq_complete(struct trace_event_raw_block_rq_completion *ctx) {
 	struct io_value *val;
 	__u64 now_ns;
 	__u64 latency_ns;
-	__u16 error_code;
+	__s32 error_code;
 	__u8 severity;
 
 	// Extract device info

--- a/tapio-agent/src/observer/storage.rs
+++ b/tapio-agent/src/observer/storage.rs
@@ -236,7 +236,7 @@ fn op_name(opcode: u8) -> &'static str {
 mod tests {
     use super::*;
 
-    fn make_event(error_code: u16, severity: u8, latency_ns: u64) -> StorageEvent {
+    fn make_event(error_code: i32, severity: u8, latency_ns: u64) -> StorageEvent {
         let mut evt = unsafe { std::mem::zeroed::<StorageEvent>() };
         evt.error_code = error_code;
         evt.severity = severity;
@@ -252,7 +252,7 @@ mod tests {
 
     #[test]
     fn classify_io_error() {
-        let evt = make_event(5, STORAGE_SEVERITY_CRITICAL, 0);
+        let evt = make_event(-5, STORAGE_SEVERITY_CRITICAL, 0);
         let a = classify(&evt).expect("should classify error");
         assert_eq!(a.event_type, STORAGE_IO_ERROR);
         assert!(matches!(a.severity, Severity::Critical));
@@ -276,7 +276,7 @@ mod tests {
 
     #[test]
     fn build_occurrence_valid() {
-        let evt = make_event(5, STORAGE_SEVERITY_CRITICAL, 0);
+        let evt = make_event(-5, STORAGE_SEVERITY_CRITICAL, 0);
         let a = classify(&evt).unwrap();
         let occ = build_occurrence(&evt, &a, 0);
         assert!(occ.validate().is_ok());
@@ -284,5 +284,6 @@ mod tests {
         let data = occ.data.unwrap();
         assert_eq!(data["comm"], "psql");
         assert_eq!(data["opcode"], "write");
+        assert_eq!(data["error_code"], -5);
     }
 }

--- a/tapio-common/src/ebpf.rs
+++ b/tapio-common/src/ebpf.rs
@@ -202,11 +202,11 @@ impl ContainerEvent {
 ///     __u32 dev_minor;      // 36
 ///     __u32 bytes;          // 40
 ///     __u32 pid;            // 44
-///     __u16 error_code;     // 48
-///     __u8  opcode;         // 50
-///     __u8  severity;       // 51
-///     __u8  comm[16];       // 52
-///     __u8  _pad[4];        // 68
+///     __s32 error_code;     // 48
+///     __u8  opcode;         // 52
+///     __u8  severity;       // 53
+///     __u8  comm[16];       // 54
+///     __u8  _pad[2];        // 70
 /// };
 /// ```
 #[repr(C)]
@@ -220,11 +220,11 @@ pub struct StorageEvent {
     pub dev_minor: u32,
     pub bytes: u32,
     pub pid: u32,
-    pub error_code: u16,
+    pub error_code: i32,
     pub opcode: u8,
     pub severity: u8,
     pub comm: [u8; 16],
-    pub _pad: [u8; 4],
+    pub _pad: [u8; 2],
 }
 
 impl StorageEvent {
@@ -295,7 +295,7 @@ fn format_ipv6(b: &[u8; 16]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::mem::size_of;
+    use std::mem::{offset_of, size_of};
 
     #[test]
     fn network_event_size() {
@@ -310,6 +310,23 @@ mod tests {
     #[test]
     fn storage_event_size() {
         assert_eq!(size_of::<StorageEvent>(), 72);
+    }
+
+    #[test]
+    fn storage_event_offsets() {
+        assert_eq!(offset_of!(StorageEvent, timestamp_ns), 0);
+        assert_eq!(offset_of!(StorageEvent, latency_ns), 8);
+        assert_eq!(offset_of!(StorageEvent, cgroup_id), 16);
+        assert_eq!(offset_of!(StorageEvent, sector), 24);
+        assert_eq!(offset_of!(StorageEvent, dev_major), 32);
+        assert_eq!(offset_of!(StorageEvent, dev_minor), 36);
+        assert_eq!(offset_of!(StorageEvent, bytes), 40);
+        assert_eq!(offset_of!(StorageEvent, pid), 44);
+        assert_eq!(offset_of!(StorageEvent, error_code), 48);
+        assert_eq!(offset_of!(StorageEvent, opcode), 52);
+        assert_eq!(offset_of!(StorageEvent, severity), 53);
+        assert_eq!(offset_of!(StorageEvent, comm), 54);
+        assert_eq!(offset_of!(StorageEvent, _pad), 70);
     }
 
     #[test]


### PR DESCRIPTION
## What

`block_rq_complete` exposes the I/O error as a **signed int** (a negative errno, e.g. `-5` for `EIO`), but `storage_monitor.c` read it into a `__u16`. As a result `kernel.storage.io_error` occurrences emitted a truncated, meaningless value (`-5` → `0xFFFB`). Anomaly *detection* (`!= 0`) was unaffected, but the emitted code was not usable.

This widens `error_code` to `__s32` / `i32`, so the true errno survives to the occurrence.

## Changes

- `ebpf/storage_monitor.c`: `error_code` `__u16` → `__s32`; trailing `_pad[4]` → `_pad[2]`. Struct stays **72 bytes** and naturally aligned.
- `tapio-common/src/ebpf.rs`: `StorageEvent.error_code` → `i32`; added `offset_of!` assertions for every field alongside the existing `size_of == 72` check (catches field reordering, not just size collisions).
- `tapio-agent/src/observer/storage.rs`: tests round-trip the true negative errno (`-5` in, `-5` out).

## Verification

Built and tested on macOS (host) **and** inside Lima (kernel **6.17**, aarch64):

- `cargo fmt --all --check`, `cargo build -p tapio-agent`, `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings` — all pass.
- All four eBPF programs **compile and load on the real kernel** (`bpftool prog load` + aya agent attach) with **no verifier rejections**.

Implemented and kernel-verified via Codex in Lima.

🤖 Generated with [Claude Code](https://claude.com/claude-code)