### PR TITLE
fix: prevent plaintext OTLP auth leak and surface evidence loss

### DIFF
--- a/tapio-agent/src/enricher.rs
+++ b/tapio-agent/src/enricher.rs
@@ -98,6 +98,10 @@ impl K8sEnricher {
         self.context_for_uid(&pod_uid)
     }
 
+    pub fn cache_size(&self) -> usize {
+        self.cgroup_cache.len()
+    }
+
     /// Resolve cgroup_id to pod UID by statting cgroup directories for all known pods.
     fn resolve_cgroup_id(&self, target_id: u64) -> Option<String> {
         use std::os::unix::fs::MetadataExt;

--- a/tapio-agent/src/main.rs
+++ b/tapio-agent/src/main.rs
@@ -76,7 +76,7 @@ fn create_sinks(
                 cfg.otlp.auth_header.clone(),
                 cfg.otlp.batch_size,
                 std::time::Duration::from_secs(cfg.otlp.flush_interval_secs),
-            ))),
+            )?)),
             other => anyhow::bail!("unknown sink: {other}"),
         }
     }
@@ -89,6 +89,7 @@ fn create_sinks(
 /// Fan-out sink that sends to all inner sinks. Failure in one doesn't block others.
 struct MultiSink {
     sinks: Vec<Box<dyn tapio_common::sink::Sink>>,
+    metrics: Option<metrics::TapioMetrics>,
 }
 
 impl tapio_common::sink::Sink for MultiSink {
@@ -98,9 +99,25 @@ impl tapio_common::sink::Sink for MultiSink {
     ) -> Result<(), tapio_common::sink::SinkError> {
         let mut last_err = None;
         for s in &self.sinks {
-            if let Err(e) = s.send(occurrence) {
-                tracing::warn!(sink = s.name(), error = %e, "sink error");
-                last_err = Some(e);
+            match s.send(occurrence) {
+                Ok(()) => {
+                    if let Some(metrics) = &self.metrics {
+                        metrics
+                            .sink_writes_total
+                            .with_label_values(&[s.name(), "ok"])
+                            .inc();
+                    }
+                }
+                Err(e) => {
+                    if let Some(metrics) = &self.metrics {
+                        metrics
+                            .sink_writes_total
+                            .with_label_values(&[s.name(), "err"])
+                            .inc();
+                    }
+                    tracing::warn!(sink = s.name(), error = %e, "sink error");
+                    last_err = Some(e);
+                }
             }
         }
         match last_err {
@@ -152,11 +169,15 @@ async fn main() -> anyhow::Result<()> {
     let cfg = config::load(std::path::Path::new(&args.config))?;
     info!("tapio v4 — kernel eyes");
 
+    let tapio_metrics = metrics::TapioMetrics::new()?;
     let sinks = create_sinks(&args, &cfg)?;
     let sink_names: Vec<&str> = sinks.iter().map(|s| s.name()).collect();
     info!(sinks = ?sink_names, "sinks configured");
 
-    let multi_sink: std::sync::Arc<MultiSink> = std::sync::Arc::new(MultiSink { sinks });
+    let multi_sink: std::sync::Arc<MultiSink> = std::sync::Arc::new(MultiSink {
+        sinks,
+        metrics: Some(tapio_metrics.clone()),
+    });
 
     #[cfg(target_os = "linux")]
     {
@@ -192,7 +213,6 @@ async fn main() -> anyhow::Result<()> {
             }
         };
 
-        let tapio_metrics = metrics::TapioMetrics::new()?;
         if enricher.is_some() {
             tapio_metrics.k8s_reflector_up.set(1);
         }
@@ -331,7 +351,107 @@ async fn main() -> anyhow::Result<()> {
 
     #[cfg(not(target_os = "linux"))]
     {
-        let _ = (args, multi_sink);
+        let _ = (args, multi_sink, tapio_metrics);
         anyhow::bail!("eBPF requires Linux — tapio-agent cannot run on this platform");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tapio_common::occurrence::{Occurrence, Outcome, Severity};
+    use tapio_common::sink::{Sink, SinkError};
+
+    struct CountingSink {
+        name: &'static str,
+        sends: Arc<AtomicUsize>,
+        fail: bool,
+    }
+
+    impl Sink for CountingSink {
+        fn send(&self, _occurrence: &Occurrence) -> Result<(), SinkError> {
+            self.sends.fetch_add(1, Ordering::Relaxed);
+            if self.fail {
+                Err(SinkError::Send("test failure".into()))
+            } else {
+                Ok(())
+            }
+        }
+
+        fn flush(&self) -> Result<(), SinkError> {
+            Ok(())
+        }
+
+        fn name(&self) -> &str {
+            self.name
+        }
+    }
+
+    #[test]
+    fn multisink_continues_after_one_sink_fails() {
+        let failed_sends = Arc::new(AtomicUsize::new(0));
+        let ok_sends = Arc::new(AtomicUsize::new(0));
+        let metrics = metrics::TapioMetrics::new().unwrap();
+        let multi = MultiSink {
+            sinks: vec![
+                Box::new(CountingSink {
+                    name: "fail",
+                    sends: failed_sends.clone(),
+                    fail: true,
+                }),
+                Box::new(CountingSink {
+                    name: "ok",
+                    sends: ok_sends.clone(),
+                    fail: false,
+                }),
+            ],
+            metrics: Some(metrics),
+        };
+        let occ = Occurrence::new(
+            "kernel.network.connection_refused",
+            Severity::Warning,
+            Outcome::Failure,
+        );
+
+        assert!(multi.send(&occ).is_err());
+        assert_eq!(failed_sends.load(Ordering::Relaxed), 1);
+        assert_eq!(ok_sends.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn multisink_records_partial_failure_metrics() {
+        let metrics = metrics::TapioMetrics::new().unwrap();
+        let registry = metrics.registry.clone();
+        let multi = MultiSink {
+            sinks: vec![
+                Box::new(CountingSink {
+                    name: "fail",
+                    sends: Arc::new(AtomicUsize::new(0)),
+                    fail: true,
+                }),
+                Box::new(CountingSink {
+                    name: "ok",
+                    sends: Arc::new(AtomicUsize::new(0)),
+                    fail: false,
+                }),
+            ],
+            metrics: Some(metrics),
+        };
+        let occ = Occurrence::new(
+            "kernel.network.connection_refused",
+            Severity::Warning,
+            Outcome::Failure,
+        );
+
+        assert!(multi.send(&occ).is_err());
+        let gathered = registry.gather();
+        let mut encoded = String::new();
+        prometheus::TextEncoder::new()
+            .encode_utf8(&gathered, &mut encoded)
+            .unwrap();
+        assert!(encoded.contains("tapio_sink_writes_total{result=\"err\",sink=\"fail\"} 1"));
+        assert!(encoded.contains("tapio_sink_writes_total{result=\"ok\",sink=\"ok\"} 1"));
     }
 }

--- a/tapio-agent/src/metrics.rs
+++ b/tapio-agent/src/metrics.rs
@@ -14,6 +14,7 @@ pub struct TapioMetrics {
     pub events_total: IntCounterVec,
     pub anomalies_total: IntCounterVec,
     pub lost_events_total: IntCounterVec,
+    pub malformed_events_total: IntCounterVec,
     pub drain_cap_total: IntCounterVec,
     pub enrichment_miss_total: IntCounterVec,
 
@@ -56,6 +57,15 @@ impl TapioMetrics {
             &["observer"],
         )?;
         registry.register(Box::new(lost_events_total.clone()))?;
+
+        let malformed_events_total = IntCounterVec::new(
+            Opts::new(
+                "tapio_malformed_events_total",
+                "Malformed or truncated eBPF records dropped by userspace",
+            ),
+            &["observer"],
+        )?;
+        registry.register(Box::new(malformed_events_total.clone()))?;
 
         let drain_cap_total = IntCounterVec::new(
             Opts::new(
@@ -101,6 +111,7 @@ impl TapioMetrics {
             events_total,
             anomalies_total,
             lost_events_total,
+            malformed_events_total,
             drain_cap_total,
             enrichment_miss_total,
             sink_writes_total,
@@ -164,10 +175,13 @@ mod tests {
         let m = TapioMetrics::new().expect("metrics registration");
         m.events_total.with_label_values(&["network"]).inc();
         m.anomalies_total
-            .with_label_values(&["network", "kernel.network.rst_storm"])
+            .with_label_values(&["network", "kernel.network.connection_refused"])
             .inc();
         m.sink_writes_total
             .with_label_values(&["stdout", "ok"])
+            .inc();
+        m.malformed_events_total
+            .with_label_values(&["network"])
             .inc();
         m.k8s_cache_size.set(42);
         m.k8s_reflector_up.set(1);
@@ -180,6 +194,7 @@ mod tests {
             .expect("encode metrics");
         assert!(buf.contains("tapio_events_total"));
         assert!(buf.contains("tapio_anomalies_total"));
+        assert!(buf.contains("tapio_malformed_events_total"));
         assert!(buf.contains("tapio_k8s_cache_size 42"));
     }
 }

--- a/tapio-agent/src/observer/container.rs
+++ b/tapio-agent/src/observer/container.rs
@@ -254,6 +254,7 @@ pub async fn run(
     let mut anomaly_count: u64 = 0;
     let mut tick_count: u64 = 0;
     let mut prev_lost: u64 = 0;
+    let mut malformed_count: u64 = 0;
     let mut enrich_total: u64 = 0;
     let mut enrich_miss: u64 = 0;
 
@@ -269,6 +270,9 @@ pub async fn run(
                     if let Some(fd) = metrics_fd {
                         let lost = super::read_percpu_sum(fd, super::METRIC_LOST_EVENTS, nr_cpus);
                         if lost > prev_lost {
+                            metrics.lost_events_total
+                                .with_label_values(&["container"])
+                                .inc_by(lost - prev_lost);
                             tracing::warn!(
                                 observer = "container",
                                 lost_total = lost,
@@ -295,7 +299,20 @@ pub async fn run(
                     let mut count = 0usize;
                     while let Some(item) = ring_buf.next() {
                         let data: &[u8] = item.as_ref();
-                        if data.len() < std::mem::size_of::<ContainerEvent>() {
+                        let expected_len = std::mem::size_of::<ContainerEvent>();
+                        if data.len() < expected_len {
+                            malformed_count += 1;
+                            metrics.malformed_events_total.with_label_values(&["container"]).inc();
+                            if super::should_warn_malformed_event(malformed_count) {
+                                tracing::warn!(
+                                    observer = "container",
+                                    source = "ring_buffer",
+                                    len = data.len(),
+                                    expected_len,
+                                    malformed_total = malformed_count,
+                                    "dropped malformed eBPF record"
+                                );
+                            }
                             count += 1;
                             if count >= super::MAX_DRAIN_PER_TICK { break; }
                             continue;
@@ -321,8 +338,10 @@ pub async fn run(
                                 };
                                 if let Some(ctx) = ctx {
                                     occ.context = Some(ctx);
+                                    metrics.k8s_cache_size.set(enricher.cache_size() as i64);
                                 } else {
                                     enrich_miss += 1;
+                                    metrics.k8s_cache_size.set(enricher.cache_size() as i64);
                                     metrics.enrichment_miss_total.with_label_values(&["container"]).inc();
                                 }
                             }

--- a/tapio-agent/src/observer/mod.rs
+++ b/tapio-agent/src/observer/mod.rs
@@ -79,6 +79,11 @@ pub fn metrics_map_fd(ebpf: &aya::Ebpf) -> Option<std::os::fd::RawFd> {
     Some(data.fd().as_fd().as_raw_fd())
 }
 
+#[cfg(target_os = "linux")]
+pub fn should_warn_malformed_event(count: u64) -> bool {
+    count <= 10 || count.is_power_of_two()
+}
+
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub mod container;
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]

--- a/tapio-agent/src/observer/network.rs
+++ b/tapio-agent/src/observer/network.rs
@@ -209,6 +209,7 @@ pub async fn run(
     let mut anomaly_count: u64 = 0;
     let mut tick_count: u64 = 0;
     let mut prev_lost: u64 = 0;
+    let mut malformed_count: u64 = 0;
     let mut enrich_total: u64 = 0;
     let mut enrich_miss: u64 = 0;
 
@@ -224,6 +225,9 @@ pub async fn run(
                     if let Some(fd) = metrics_fd {
                         let lost = super::read_percpu_sum(fd, super::METRIC_LOST_EVENTS, nr_cpus);
                         if lost > prev_lost {
+                            metrics.lost_events_total
+                                .with_label_values(&["network"])
+                                .inc_by(lost - prev_lost);
                             tracing::warn!(
                                 observer = "network",
                                 lost_total = lost,
@@ -250,7 +254,20 @@ pub async fn run(
                     let mut count = 0usize;
                     while let Some(item) = ring_buf.next() {
                         let data: &[u8] = item.as_ref();
-                        if data.len() < std::mem::size_of::<NetworkEvent>() {
+                        let expected_len = std::mem::size_of::<NetworkEvent>();
+                        if data.len() < expected_len {
+                            malformed_count += 1;
+                            metrics.malformed_events_total.with_label_values(&["network"]).inc();
+                            if super::should_warn_malformed_event(malformed_count) {
+                                tracing::warn!(
+                                    observer = "network",
+                                    source = "ring_buffer",
+                                    len = data.len(),
+                                    expected_len,
+                                    malformed_total = malformed_count,
+                                    "dropped malformed eBPF record"
+                                );
+                            }
                             count += 1;
                             if count >= super::MAX_DRAIN_PER_TICK { break; }
                             continue;

--- a/tapio-agent/src/observer/node_pmc.rs
+++ b/tapio-agent/src/observer/node_pmc.rs
@@ -323,6 +323,7 @@ pub async fn run(
     let mut anomaly_count: u64 = 0;
     let mut tick_count: u64 = 0;
     let mut prev_lost: u64 = 0;
+    let mut malformed_count: u64 = 0;
 
     loop {
         tokio::select! {
@@ -335,6 +336,9 @@ pub async fn run(
                 if tick_count.is_multiple_of(super::LOST_EVENTS_CHECK_INTERVAL) && let Some(fd) = metrics_fd {
                     let lost = super::read_percpu_sum(fd, super::METRIC_LOST_EVENTS, num_cpus as usize);
                     if lost > prev_lost {
+                        metrics.lost_events_total
+                            .with_label_values(&["node_pmc"])
+                            .inc_by(lost - prev_lost);
                         tracing::warn!(
                             observer = "node_pmc",
                             lost_total = lost,
@@ -348,7 +352,20 @@ pub async fn run(
                     let mut count = 0usize;
                     while let Some(item) = ring_buf.next() {
                         let data: &[u8] = item.as_ref();
-                        if data.len() < std::mem::size_of::<PmcEvent>() {
+                        let expected_len = std::mem::size_of::<PmcEvent>();
+                        if data.len() < expected_len {
+                            malformed_count += 1;
+                            metrics.malformed_events_total.with_label_values(&["node_pmc"]).inc();
+                            if super::should_warn_malformed_event(malformed_count) {
+                                tracing::warn!(
+                                    observer = "node_pmc",
+                                    source = "ring_buffer",
+                                    len = data.len(),
+                                    expected_len,
+                                    malformed_total = malformed_count,
+                                    "dropped malformed eBPF record"
+                                );
+                            }
                             count += 1;
                             if count >= super::MAX_DRAIN_PER_TICK { break; }
                             continue;

--- a/tapio-agent/src/observer/storage.rs
+++ b/tapio-agent/src/observer/storage.rs
@@ -134,6 +134,7 @@ pub async fn run(
     let mut anomaly_count: u64 = 0;
     let mut tick_count: u64 = 0;
     let mut prev_lost: u64 = 0;
+    let mut malformed_count: u64 = 0;
     let mut enrich_total: u64 = 0;
     let mut enrich_miss: u64 = 0;
 
@@ -149,6 +150,9 @@ pub async fn run(
                     if let Some(fd) = metrics_fd {
                         let lost = super::read_percpu_sum(fd, super::METRIC_LOST_EVENTS, nr_cpus);
                         if lost > prev_lost {
+                            metrics.lost_events_total
+                                .with_label_values(&["storage"])
+                                .inc_by(lost - prev_lost);
                             tracing::warn!(
                                 observer = "storage",
                                 lost_total = lost,
@@ -175,7 +179,20 @@ pub async fn run(
                     let mut count = 0usize;
                     while let Some(item) = ring_buf.next() {
                         let data: &[u8] = item.as_ref();
-                        if data.len() < std::mem::size_of::<StorageEvent>() {
+                        let expected_len = std::mem::size_of::<StorageEvent>();
+                        if data.len() < expected_len {
+                            malformed_count += 1;
+                            metrics.malformed_events_total.with_label_values(&["storage"]).inc();
+                            if super::should_warn_malformed_event(malformed_count) {
+                                tracing::warn!(
+                                    observer = "storage",
+                                    source = "ring_buffer",
+                                    len = data.len(),
+                                    expected_len,
+                                    malformed_total = malformed_count,
+                                    "dropped malformed eBPF record"
+                                );
+                            }
                             count += 1;
                             if count >= super::MAX_DRAIN_PER_TICK { break; }
                             continue;
@@ -193,8 +210,10 @@ pub async fn run(
                                     enrich_total += 1;
                                     if let Some(ctx) = enricher.enrich(cgroup_id) {
                                         occ.context = Some(ctx);
+                                        metrics.k8s_cache_size.set(enricher.cache_size() as i64);
                                     } else {
                                         enrich_miss += 1;
+                                        metrics.k8s_cache_size.set(enricher.cache_size() as i64);
                                         metrics.enrichment_miss_total.with_label_values(&["storage"]).inc();
                                     }
                                 }

--- a/tapio-agent/src/sink/http.rs
+++ b/tapio-agent/src/sink/http.rs
@@ -198,6 +198,15 @@ fn post_json(endpoint: &str, body: &[u8]) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tapio_common::occurrence::{Outcome, Severity};
+
+    fn occurrence() -> Occurrence {
+        Occurrence::new(
+            "kernel.network.connection_refused",
+            Severity::Warning,
+            Outcome::Failure,
+        )
+    }
 
     #[test]
     fn name_is_stable() {
@@ -208,12 +217,77 @@ mod tests {
     #[test]
     fn buffers_below_batch_size_without_sending() {
         let sink = HttpSink::new("http://127.0.0.1:1", 100, Duration::from_secs(3600));
-        let occ = Occurrence::new(
-            "kernel.network.rst_storm",
-            tapio_common::occurrence::Severity::Error,
-            tapio_common::occurrence::Outcome::Failure,
-        );
+        let occ = occurrence();
         // Below batch size and inside flush interval — should buffer, never attempt I/O.
         assert!(sink.send(&occ).is_ok());
+    }
+
+    #[test]
+    fn failed_send_sets_backoff_and_drops_batch() {
+        let sink = HttpSink::new("http://127.0.0.1:1", 1, Duration::from_secs(3600));
+        let occ = occurrence();
+
+        assert!(sink.send(&occ).is_ok());
+
+        let inner = sink.inner.lock().unwrap();
+        assert_eq!(inner.buffer.len(), 0);
+        assert!(inner.next_retry > Instant::now());
+        assert_eq!(inner.backoff, INITIAL_BACKOFF * 2);
+    }
+
+    #[test]
+    fn backoff_prevents_immediate_retry_and_keeps_buffered_events() {
+        let sink = HttpSink::new("http://127.0.0.1:1", 1, Duration::from_secs(3600));
+        let occ = occurrence();
+
+        assert!(sink.send(&occ).is_ok());
+        assert!(sink.send(&occ).is_ok());
+
+        let inner = sink.inner.lock().unwrap();
+        assert_eq!(inner.buffer.len(), 1);
+        assert!(inner.next_retry > Instant::now());
+    }
+
+    #[test]
+    fn buffer_overflow_drops_oldest_while_in_backoff() {
+        let sink = HttpSink::new("http://127.0.0.1:1", 1, Duration::from_secs(3600));
+        let occ = occurrence();
+
+        assert!(sink.send(&occ).is_ok());
+        for _ in 0..12 {
+            assert!(sink.send(&occ).is_ok());
+        }
+
+        let inner = sink.inner.lock().unwrap();
+        assert!(inner.buffer.len() <= inner.max_buffer);
+        assert!(inner.buffer.len() < 12);
+    }
+
+    #[test]
+    fn post_json_accepts_http_endpoint() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 512];
+            let n = stream.read(&mut buf).unwrap();
+            let request = String::from_utf8_lossy(&buf[..n]);
+            assert!(request.starts_with("POST /v1/occurrences HTTP/1.1"));
+            stream
+                .write_all(b"HTTP/1.1 204 No Content\r\n\r\n")
+                .unwrap();
+        });
+
+        post_json(&format!("http://{addr}"), b"[]").unwrap();
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn post_json_rejects_https_endpoint() {
+        let err = post_json("https://127.0.0.1:4318", b"[]").unwrap_err();
+        assert!(err.contains("http://"));
     }
 }

--- a/tapio-agent/src/sink/http.rs
+++ b/tapio-agent/src/sink/http.rs
@@ -81,7 +81,7 @@ impl Sink for HttpSink {
         }; // lock released here — before any I/O
 
         if let Some(batch) = batch {
-            self.post_batch(batch);
+            self.post_batch(batch)?;
         }
 
         Ok(())
@@ -101,8 +101,7 @@ impl Sink for HttpSink {
             batch
         }; // lock released here
 
-        self.post_batch(batch);
-        Ok(())
+        self.post_batch(batch)
     }
 
     fn name(&self) -> &str {
@@ -112,16 +111,16 @@ impl Sink for HttpSink {
 
 impl HttpSink {
     /// POST batch to endpoint. On failure, batch is lost (logged + backoff updated).
-    fn post_batch(&self, batch: Vec<Occurrence>) {
+    fn post_batch(&self, batch: Vec<Occurrence>) -> Result<(), SinkError> {
         if batch.is_empty() {
-            return;
+            return Ok(());
         }
 
         let payload = match serde_json::to_vec(&batch) {
             Ok(p) => p,
             Err(e) => {
                 tracing::warn!(error = %e, "http sink: failed to serialize batch");
-                return;
+                return Err(SinkError::Serialization(e.to_string()));
             }
         };
 
@@ -131,6 +130,7 @@ impl HttpSink {
                 if let Ok(mut inner) = self.inner.lock() {
                     inner.backoff = INITIAL_BACKOFF;
                 }
+                Ok(())
             }
             Err(e) => {
                 if let Ok(mut inner) = self.inner.lock() {
@@ -143,6 +143,10 @@ impl HttpSink {
                     dropped = batch.len(),
                     "http sink: send failed, batch dropped"
                 );
+                Err(SinkError::Send(format!(
+                    "http sink: send failed, dropped {} events: {e}",
+                    batch.len()
+                )))
             }
         }
     }
@@ -227,7 +231,7 @@ mod tests {
         let sink = HttpSink::new("http://127.0.0.1:1", 1, Duration::from_secs(3600));
         let occ = occurrence();
 
-        assert!(sink.send(&occ).is_ok());
+        assert!(sink.send(&occ).is_err());
 
         let inner = sink.inner.lock().unwrap();
         assert_eq!(inner.buffer.len(), 0);
@@ -240,7 +244,7 @@ mod tests {
         let sink = HttpSink::new("http://127.0.0.1:1", 1, Duration::from_secs(3600));
         let occ = occurrence();
 
-        assert!(sink.send(&occ).is_ok());
+        assert!(sink.send(&occ).is_err());
         assert!(sink.send(&occ).is_ok());
 
         let inner = sink.inner.lock().unwrap();
@@ -253,7 +257,7 @@ mod tests {
         let sink = HttpSink::new("http://127.0.0.1:1", 1, Duration::from_secs(3600));
         let occ = occurrence();
 
-        assert!(sink.send(&occ).is_ok());
+        assert!(sink.send(&occ).is_err());
         for _ in 0..12 {
             assert!(sink.send(&occ).is_ok());
         }

--- a/tapio-agent/src/sink/otlp.rs
+++ b/tapio-agent/src/sink/otlp.rs
@@ -138,6 +138,10 @@ fn occurrence_to_log_record(occ: &Occurrence) -> LogRecord {
 
 /// Exports anomaly events as OTLP/HTTP logs (protobuf + gzip) to any
 /// OTLP-compatible collector. Batches and retries with backoff.
+///
+/// This minimal sink supports plaintext HTTP only. Configure TLS at a local
+/// OpenTelemetry Collector, sidecar, node-local proxy, or trusted network
+/// boundary rather than sending an HTTPS URL through this TCP-only client.
 pub struct OtlpSink {
     endpoint: String,
     auth_header: Option<String>,
@@ -158,9 +162,10 @@ impl OtlpSink {
         auth_header: Option<String>,
         batch_size: usize,
         flush_interval: Duration,
-    ) -> Self {
-        Self {
-            endpoint: endpoint.trim_end_matches('/').to_string(),
+    ) -> Result<Self, SinkError> {
+        let endpoint = normalize_http_endpoint(endpoint)?;
+        Ok(Self {
+            endpoint,
             auth_header,
             batch_size,
             flush_interval,
@@ -169,7 +174,7 @@ impl OtlpSink {
                 buffer: Vec::with_capacity(batch_size),
                 last_flush: Instant::now(),
             }),
-        }
+        })
     }
 
     fn export_batch(&self, batch: Vec<Occurrence>) -> Result<(), SinkError> {
@@ -241,12 +246,11 @@ impl OtlpSink {
         use std::io::{BufRead, BufReader};
         use std::net::TcpStream;
 
-        let url_parsed: Vec<&str> = url
-            .strip_prefix("http://")
-            .or_else(|| url.strip_prefix("https://"))
-            .unwrap_or(url)
-            .splitn(2, '/')
-            .collect();
+        let url = url.strip_prefix("http://").ok_or_else(|| {
+            SinkError::Connection(format!("OTLP endpoint must use http://: {url}"))
+        })?;
+
+        let url_parsed: Vec<&str> = url.splitn(2, '/').collect();
 
         let host = url_parsed[0];
         let path = if url_parsed.len() > 1 {
@@ -309,6 +313,34 @@ impl OtlpSink {
 
         Ok(status)
     }
+}
+
+fn normalize_http_endpoint(endpoint: &str) -> Result<String, SinkError> {
+    let trimmed = endpoint.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        return Err(SinkError::Connection("OTLP endpoint is empty".into()));
+    }
+    if trimmed.starts_with("https://") {
+        return Err(SinkError::Connection(
+            "OTLP sink supports plaintext http:// only; use a local collector or TLS-terminating proxy for HTTPS"
+                .into(),
+        ));
+    }
+    if !trimmed.starts_with("http://") {
+        return Err(SinkError::Connection(format!(
+            "OTLP endpoint must start with http://: {trimmed}"
+        )));
+    }
+
+    let rest = &trimmed["http://".len()..];
+    let host_port = rest.split('/').next().unwrap_or_default();
+    if host_port.is_empty() {
+        return Err(SinkError::Connection(format!(
+            "OTLP endpoint missing host: {trimmed}"
+        )));
+    }
+
+    Ok(trimmed.to_string())
 }
 
 /// Max buffer entries before oldest are dropped (10x batch_size).
@@ -456,5 +488,38 @@ mod tests {
         let compressed = encoder.finish().unwrap();
 
         assert!(compressed.len() < proto_bytes.len());
+    }
+
+    #[test]
+    fn rejects_https_endpoint_before_auth_can_be_sent() {
+        let err = match OtlpSink::new(
+            "https://collector.example:4318",
+            Some("Bearer secret".into()),
+            10,
+            Duration::from_secs(1),
+        ) {
+            Ok(_) => panic!("https endpoint should be rejected"),
+            Err(err) => err,
+        };
+
+        assert!(err.to_string().contains("http:// only"));
+    }
+
+    #[test]
+    fn accepts_http_endpoint() {
+        let sink = OtlpSink::new("http://127.0.0.1:4318/", None, 10, Duration::from_secs(1))
+            .expect("http endpoint");
+        assert_eq!(sink.endpoint, "http://127.0.0.1:4318");
+    }
+
+    #[test]
+    fn rejects_malformed_endpoint() {
+        for endpoint in ["", "collector.example:4318", "ftp://collector.example"] {
+            let err = match OtlpSink::new(endpoint, None, 10, Duration::from_secs(1)) {
+                Ok(_) => panic!("malformed endpoint should be rejected"),
+                Err(err) => err,
+            };
+            assert!(err.to_string().contains("OTLP endpoint"));
+        }
     }
 }

--- a/tapio-agent/src/sink/otlp.rs
+++ b/tapio-agent/src/sink/otlp.rs
@@ -383,6 +383,7 @@ impl Sink for OtlpSink {
             && let Err(e) = self.export_batch(batch)
         {
             tracing::warn!(error = %e, "otlp sink: batch export failed, data dropped");
+            return Err(e);
         }
 
         Ok(())
@@ -404,6 +405,7 @@ impl Sink for OtlpSink {
 
         if let Err(e) = self.export_batch(batch) {
             tracing::warn!(error = %e, "otlp sink: flush export failed, data dropped");
+            return Err(e);
         }
         Ok(())
     }

--- a/tapio-cli/src/main.rs
+++ b/tapio-cli/src/main.rs
@@ -176,14 +176,17 @@ async fn cmd_watch(data_dir: &Path, json: bool, filters: &[&str]) -> anyhow::Res
                 };
                 let mut new_occs = Vec::new();
                 for entry in entries {
-                    let Ok(entry) = entry else { continue };
+                    let Ok(entry) = entry else {
+                        eprintln!("warning: failed to read occurrence directory entry");
+                        continue;
+                    };
                     if !seen.insert(entry.file_name()) { continue; }
                     let path = entry.path();
-                    if path.extension().is_some_and(|e| e == "json")
-                        && let Ok(data) = std::fs::read_to_string(&path)
-                        && let Ok(occ) = serde_json::from_str::<Occurrence>(&data)
-                    {
-                        new_occs.push(occ);
+                    if path.extension().is_some_and(|e| e == "json") {
+                        match read_occurrence_file(&path) {
+                            Ok(occ) => new_occs.push(occ),
+                            Err(e) => eprintln!("warning: skipped {}: {e}", path.display()),
+                        }
                     }
                 }
                 new_occs.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
@@ -610,16 +613,30 @@ fn load_occurrences(data_dir: &Path) -> anyhow::Result<Vec<Occurrence>> {
         return Ok(occurrences);
     }
     for entry in std::fs::read_dir(data_dir)? {
-        let entry = entry?;
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(e) => {
+                eprintln!("warning: failed to read occurrence directory entry: {e}");
+                continue;
+            }
+        };
         let path = entry.path();
-        if path.extension().is_some_and(|e| e == "json")
-            && let Ok(data) = std::fs::read_to_string(&path)
-            && let Ok(occ) = serde_json::from_str::<Occurrence>(&data)
-        {
-            occurrences.push(occ);
+        if path.extension().is_some_and(|e| e == "json") {
+            match read_occurrence_file(&path) {
+                Ok(occ) => occurrences.push(occ),
+                Err(e) => eprintln!("warning: skipped {}: {e}", path.display()),
+            }
         }
     }
     Ok(occurrences)
+}
+
+fn read_occurrence_file(path: &Path) -> anyhow::Result<Occurrence> {
+    let data = std::fs::read_to_string(path)
+        .map_err(|e| anyhow::anyhow!("failed to read occurrence file: {e}"))?;
+    let occ = serde_json::from_str::<Occurrence>(&data)
+        .map_err(|e| anyhow::anyhow!("failed to parse occurrence JSON: {e}"))?;
+    Ok(occ)
 }
 
 fn observer_category(occurrence_type: &str) -> &str {
@@ -809,6 +826,32 @@ mod tests {
     }
 
     #[test]
+    fn load_occurrences_skips_corrupt_json_with_warning_path() {
+        let dir = std::env::temp_dir().join(format!("tapio-cli-corrupt-{}", ulid_like_test_id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("bad.json"), b"{not-json").unwrap();
+
+        let loaded = load_occurrences(&dir).unwrap();
+        assert!(loaded.is_empty());
+        assert!(
+            read_occurrence_file(&dir.join("bad.json"))
+                .unwrap_err()
+                .to_string()
+                .contains("failed to parse occurrence JSON")
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn read_occurrence_file_reports_missing_file() {
+        let path =
+            std::env::temp_dir().join(format!("tapio-cli-missing-{}.json", ulid_like_test_id()));
+        let err = read_occurrence_file(&path).unwrap_err();
+        assert!(err.to_string().contains("failed to read occurrence file"));
+    }
+
+    #[test]
     fn missing_data_dir_returns_no_occurrences() {
         let dir = std::env::temp_dir().join("tapio-cli-does-not-exist-zzz");
         let loaded = load_occurrences(&dir).unwrap();
@@ -822,5 +865,15 @@ mod tests {
         let cli = Cli::try_parse_from(["tapio", "status"]).unwrap();
         assert_eq!(cli.data_dir, PathBuf::from("/tmp/tapio-env-dir"));
         unsafe { std::env::remove_var("TAPIO_DATA_DIR") };
+    }
+
+    fn ulid_like_test_id() -> String {
+        format!(
+            "{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        )
     }
 }


### PR DESCRIPTION
## Summary
- reject HTTPS OTLP endpoints before any plaintext TCP request or Authorization header can be sent
- surface malformed/truncated eBPF records with counters and bounded warnings
- wire lost-event, sink write, and K8s cache metrics
- warn on unreadable/corrupt occurrence files instead of silently skipping them
- add deterministic sink and MultiSink resilience tests

## Verification
- cargo fmt --all
- cargo test -p tapio-agent
- cargo test -p tapio-cli
- cargo test --workspace
- cargo build --release --workspace

## Notes
- No TLS/HTTP framework added. The OTLP sink remains plaintext HTTP only and rejects HTTPS explicitly.