### PR TITLE
chore: remove dead dependencies and unused features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,30 +227,6 @@ dependencies = [
  "object",
  "once_cell",
  "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
-name = "aya-log"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b600d806c1d07d3b81ab5f4a2a95fd80f479a0d3f1d68f29064d660865f85f02"
-dependencies = [
- "aya",
- "aya-log-common",
- "bytes",
- "log",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
-name = "aya-log-common"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "befef9fe882e63164a2ba0161874e954648a72b0e1c4b361f532d590638c4eec"
-dependencies = [
- "num_enum",
 ]
 
 [[package]]
@@ -1243,27 +1219,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_enum"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
-dependencies = [
- "num_enum_derive",
- "rustversion",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1947,7 +1902,6 @@ dependencies = [
  "anyhow",
  "axum",
  "aya",
- "aya-log",
  "chrono",
  "clap",
  "dashmap",
@@ -1962,7 +1916,6 @@ dependencies = [
  "serde_json",
  "tapio-common",
  "tokio",
- "tokio-util",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -2227,16 +2180,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,15 +2189,12 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,9 @@ repository = "https://github.com/yairfalse/tapio"
 [workspace.dependencies]
 # eBPF
 aya = "0.13"
-aya-log = "0.2"
 
 # Async
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "sync", "time", "fs"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "sync", "time"] }
 
 # K8s enrichment
 kube = { version = "0.98", features = ["runtime", "client"] }
@@ -34,12 +33,11 @@ serde_json = "1"
 
 # Observability
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 prometheus = { version = "0.13", default-features = false }
 
 # HTTP (metrics + health only)
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }
-tokio-util = "0.7"
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -64,7 +62,6 @@ chrono = { version = "0.4", default-features = false, features = ["serde", "cloc
 ulid = "1"
 thiserror = "2"
 anyhow = "1"
-bytes = "1"
 
 # Workspace crates
 tapio-common = { path = "tapio-common" }

--- a/tapio-agent/Cargo.toml
+++ b/tapio-agent/Cargo.toml
@@ -21,14 +21,12 @@ clap = { workspace = true }
 anyhow = { workspace = true }
 prometheus = { workspace = true }
 axum = { workspace = true }
-tokio-util = { workspace = true }
 prost = { workspace = true }
 flate2 = { workspace = true }
 chrono = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 aya = { workspace = true }
-aya-log = { workspace = true }
 libc = { workspace = true }
 kube = { workspace = true }
 k8s-openapi = { workspace = true }


### PR DESCRIPTION
## Summary
- remove direct bytes, tokio-util, and aya-log dependencies
- remove unused tokio fs feature
- remove unused tracing-subscriber json feature
- update Cargo.lock accordingly

## Verification
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- cargo build --release --workspace
- cargo tree --workspace --target all

## Notes
- bytes and tokio-util still appear transitively through axum/tower/kube/prost; this PR removes only direct unused weight.