### PR TITLE
fix: sync anomaly catalog and tighten occurrence validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Tapio is organized around four observers, each watching a specific slice of kern
 
 | Observer | Kernel sources | Anomalies |
 |----------|----------------|-----------|
-| Network | `inet_sock_set_state`, `tcp_receive_reset`, `tcp_retransmit_skb` | `kernel.network.connection_refused`, `kernel.network.connection_timeout`, `kernel.network.retransmit_spike`, `kernel.network.rtt_degradation`, `kernel.network.rst_storm` |
+| Network | `inet_sock_set_state`, `tcp_receive_reset`, `tcp_retransmit_skb` | `kernel.network.connection_refused`, `kernel.network.connection_timeout`, `kernel.network.retransmit_spike`, `kernel.network.rtt_degradation` |
 | Container | `sched_process_exit`, `oom/mark_victim` | `kernel.container.oom_kill`, `kernel.container.abnormal_exit` |
 | Storage | `block_rq_issue`, `block_rq_complete` | `kernel.storage.io_error`, `kernel.storage.latency_spike` |
 | Node PMC | `perf_event` counters: cycles, instructions, stalls | `kernel.node.cpu_stall`, `kernel.node.memory_pressure`, `kernel.node.ipc_degradation` |
@@ -117,7 +117,7 @@ Tapio filters at two levels, choosing the cheapest place to drop noise.
 |----------|------------------|----------|
 | Storage | BPF | Only I/O errors and latency spikes cross into userspace. |
 | Container | BPF | Only abnormal exits cross: non-zero exit code, terminating signal, or OOM kill. |
-| Network | Rust | BPF emits state transitions and network signals; Rust classifies retransmit spikes, RTT degradation, reset storms, connection failures, and timeouts. |
+| Network | Rust | BPF emits state transitions and network signals; Rust classifies retransmit spikes, RTT degradation, connection failures, and timeouts. |
 | Node PMC | Rust | BPF samples performance counters; Rust detects IPC degradation, CPU stalls, and memory pressure. |
 
 Thresholds for the Rust-side and BPF-side detectors (RTT spike ratio, I/O latency, PMC stall percentages, IPC) are tunable via the TOML config file — see [Agent](#agent).

--- a/tapio-cli/src/main.rs
+++ b/tapio-cli/src/main.rs
@@ -636,6 +636,8 @@ fn read_occurrence_file(path: &Path) -> anyhow::Result<Occurrence> {
         .map_err(|e| anyhow::anyhow!("failed to read occurrence file: {e}"))?;
     let occ = serde_json::from_str::<Occurrence>(&data)
         .map_err(|e| anyhow::anyhow!("failed to parse occurrence JSON: {e}"))?;
+    occ.validate()
+        .map_err(|errors| anyhow::anyhow!("invalid occurrence: {}", errors.join("; ")))?;
     Ok(occ)
 }
 
@@ -838,6 +840,32 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("failed to parse occurrence JSON")
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_occurrences_skips_invalid_occurrence_with_warning_path() {
+        use tapio_common::occurrence::Outcome;
+
+        let mut occ = Occurrence::new(
+            "kernel.network.connection_refused",
+            Severity::Warning,
+            Outcome::Failure,
+        );
+        occ.occurrence_type = "kernel.network".into();
+        let dir = std::env::temp_dir().join(format!("tapio-cli-invalid-{}", ulid_like_test_id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("invalid.json"), serde_json::to_vec(&occ).unwrap()).unwrap();
+
+        let loaded = load_occurrences(&dir).unwrap();
+        assert!(loaded.is_empty());
+        assert!(
+            read_occurrence_file(&dir.join("invalid.json"))
+                .unwrap_err()
+                .to_string()
+                .contains("invalid occurrence")
         );
 
         std::fs::remove_dir_all(&dir).ok();

--- a/tapio-common/src/events.rs
+++ b/tapio-common/src/events.rs
@@ -11,7 +11,6 @@ pub const NETWORK_CONNECTION_REFUSED: &str = "kernel.network.connection_refused"
 pub const NETWORK_CONNECTION_TIMEOUT: &str = "kernel.network.connection_timeout";
 pub const NETWORK_RETRANSMIT_SPIKE: &str = "kernel.network.retransmit_spike";
 pub const NETWORK_RTT_DEGRADATION: &str = "kernel.network.rtt_degradation";
-pub const NETWORK_RST_STORM: &str = "kernel.network.rst_storm";
 
 // Container anomalies
 pub const CONTAINER_OOM_KILL: &str = "kernel.container.oom_kill";

--- a/tapio-common/src/occurrence.rs
+++ b/tapio-common/src/occurrence.rs
@@ -196,8 +196,11 @@ impl Occurrence {
         }
         if self.occurrence_type.is_empty() {
             errors.push("type is required".into());
-        } else if !self.occurrence_type.contains('.') {
-            errors.push("type must have at least 2 dot-separated segments".into());
+        } else {
+            let segments: Vec<&str> = self.occurrence_type.split('.').collect();
+            if segments.len() != 3 || segments.iter().any(|segment| segment.is_empty()) {
+                errors.push("type must have exactly 3 non-empty dot-separated segments".into());
+            }
         }
         if self.protocol_version.is_empty() {
             errors.push("protocol_version is required".into());
@@ -259,12 +262,12 @@ mod tests {
     #[test]
     fn type_field_serializes_as_type_not_occurrence_type() {
         let occ = Occurrence::new(
-            "kernel.network.rst_storm",
+            "kernel.network.connection_refused",
             Severity::Error,
             Outcome::Failure,
         );
         let json = serde_json::to_string(&occ).unwrap();
-        assert!(json.contains("\"type\":\"kernel.network.rst_storm\""));
+        assert!(json.contains("\"type\":\"kernel.network.connection_refused\""));
         assert!(!json.contains("occurrence_type"));
     }
 
@@ -295,6 +298,18 @@ mod tests {
     #[test]
     fn validate_catches_bad_type_format() {
         let occ = Occurrence::new("kernel", Severity::Info, Outcome::Success);
+        assert!(occ.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_two_segment_type() {
+        let occ = Occurrence::new("kernel.network", Severity::Info, Outcome::Success);
+        assert!(occ.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_empty_type_segment() {
+        let occ = Occurrence::new("kernel..network", Severity::Info, Outcome::Success);
         assert!(occ.validate().is_err());
     }
 


### PR DESCRIPTION
## Summary
- remove documented-but-unemitted kernel.network.rst_storm from docs/catalog
- tighten occurrence type validation to exactly three non-empty dot-separated segments
- validate occurrence files at CLI load boundaries
- add tests for invalid occurrence types and invalid occurrence files

## Verification
- cargo fmt --all
- cargo test -p tapio-common
- cargo test -p tapio-cli
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- cargo build --release --workspace