### PR TITLE
feat(controller): distribute compiled config with ETag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,12 +302,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -376,6 +414,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -867,6 +915,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,6 +1053,9 @@ dependencies = [
  "axum",
  "serde",
  "serde_json",
+ "serde_yaml",
+ "sha2",
+ "tapio-profile",
  "tapio-wire",
  "tokio",
  "tracing",
@@ -1201,6 +1263,12 @@ dependencies = [
  "tracing",
  "tracing-core",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ulid"

--- a/docs/agent-controller.md
+++ b/docs/agent-controller.md
@@ -28,14 +28,14 @@ Agent to controller communication is agent-initiated HTTP/1.1 plus JSON in v0. T
 The v0 protocol is `tapio-wire/v1`:
 
 - `POST /v1/agents/hello`
-- `GET /v1/agents/config?agent_id=<agent-id>&node_name=<node-name>&version=<current-version>`
+- `GET /v1/agents/config?agent_id=<agent-id>&node_name=<node-name>`
 - `POST /v1/agents/heartbeat`
 - `POST /v1/events`
 
 Payloads are small, bounded, and versioned. Unknown future JSON fields are ignored by default, while missing required fields and unsupported wire versions fail clearly.
 
 See [wire-api-standard.md](wire-api-standard.md) for the versioning,
-compatibility, config identity, caching, and error-envelope policy.
+compatibility, config identity, ETag caching, and error-envelope policy.
 
 ## Security Assumptions
 

--- a/docs/wire-api-standard.md
+++ b/docs/wire-api-standard.md
@@ -69,6 +69,19 @@ The hash is computed over the canonical `serde_json::to_vec` bytes of the
 `CompiledConfig` value. Agents and operators should treat the hash, not the
 generation, as the authoritative identity of the desired config.
 
+## Profile Input
+
+In v0, profile documents enter the controller at startup. The controller may
+parse an operator-trusted EvidenceProfile YAML file, validate it with
+`tapio-profile`, compile it into `CompiledConfig`, and fail startup on any
+parse or validation error.
+
+The controller currently uses `serde_yaml 0.9` for this startup-only parser.
+That crate is archived upstream, so it is intentionally contained to
+`tapio-controller`, never linked into `tapio-agent` or `tapio-cli`, and
+replaceable behind the same `Deserialize` boundary. YAML parsing is not part
+of the profile core API.
+
 ## Config Caching
 
 `GET /v1/agents/config` returns:
@@ -86,6 +99,10 @@ If-None-Match: "<config_hash>"
 When the tag matches the active config, the controller returns
 `304 Not Modified` with no body. When it does not match, the controller returns
 `200 OK` with the full `ConfigResponse`.
+
+v0 uses exact single-tag matching only. It does not implement HTTP list
+matching, weak validators, or `*` matching because the agent/controller path is
+a closed protocol, not a general-purpose cache interface.
 
 This is the v1 scaling story: many agents poll, and most receive cheap `304`
 responses.

--- a/scripts/check-dependency-boundaries.sh
+++ b/scripts/check-dependency-boundaries.sh
@@ -23,6 +23,8 @@ guidance() {
     kube)        printf 'must not run a Kubernetes client. Kubernetes enrichment belongs in tapio-controller.' ;;
     k8s-openapi) printf 'must not pull Kubernetes API types. They belong in tapio-controller.' ;;
     tapio-profile) printf 'must not validate or compile Evidence Profiles. It consumes compiled wire config only.' ;;
+    serde_yaml)   printf 'must not parse operator YAML. Profile input belongs in tapio-controller.' ;;
+    sha2)         printf 'must not compute controller config identities. Config hashing belongs in tapio-controller.' ;;
     *)           printf 'is a forbidden dependency for this crate.' ;;
   esac
 }
@@ -46,10 +48,10 @@ check_boundary() {
 }
 
 # tapio-agent: node observer. No server, no gRPC, no Kubernetes client, no profile logic.
-check_boundary tapio-agent kube k8s-openapi axum hyper tonic reqwest tapio-profile
+check_boundary tapio-agent kube k8s-openapi axum hyper tonic reqwest tapio-profile serde_yaml sha2
 
 # tapio-cli: platform-independent local inspection. No profile validation/compilation path.
-check_boundary tapio-cli tapio-profile
+check_boundary tapio-cli tapio-profile serde_yaml sha2
 
 # tapio-wire: tiny protocol structs. No server/client frameworks at all.
 check_boundary tapio-wire kube k8s-openapi axum hyper tonic reqwest

--- a/tapio-controller/Cargo.toml
+++ b/tapio-controller/Cargo.toml
@@ -11,10 +11,13 @@ path = "src/main.rs"
 
 [dependencies]
 tapio-wire = { workspace = true }
+tapio-profile = { workspace = true }
 anyhow = { workspace = true }
 axum = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = "0.9"
+sha2 = "0.10"
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/tapio-controller/src/lib.rs
+++ b/tapio-controller/src/lib.rs
@@ -1,19 +1,83 @@
 use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 
 use axum::extract::State;
-use axum::http::{StatusCode, Uri};
+use axum::http::{HeaderMap, HeaderValue, StatusCode, Uri, header};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde::Serialize;
+use sha2::{Digest, Sha256};
+use tapio_profile::{BuiltinSet, EvidenceProfile, ProfileError, compile, validate};
 use tapio_wire::{
-    ConfigResponse, EventBatchRequest, EventBatchResponse, HeartbeatRequest, HeartbeatResponse,
-    HelloRequest, HelloResponse, WireError,
+    BatchingConfig, CompiledConfig, ConfigResponse, EventBatchRequest, EventBatchResponse,
+    HeartbeatRequest, HeartbeatResponse, HelloRequest, HelloResponse, WIRE_VERSION, WireError,
 };
 
 const CONTROLLER_ID: &str = "tapio-controller/default";
+const DEFAULT_PROFILE_YAML: &str = r#"
+apiVersion: tapio.false.systems/v0
+kind: EvidenceProfile
+base: production-default
+"#;
+const INITIAL_GENERATION: u32 = 1;
+
+#[derive(Debug)]
+pub enum ConfigLoadError {
+    ReadProfile {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    ParseProfile {
+        path: Option<PathBuf>,
+        source: serde_yaml::Error,
+    },
+    ValidateProfile {
+        path: Option<PathBuf>,
+        source: ProfileError,
+    },
+    SerializeConfig {
+        source: serde_json::Error,
+    },
+}
+
+impl std::fmt::Display for ConfigLoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ReadProfile { path, source } => {
+                write!(f, "failed to read profile {}: {source}", path.display())
+            }
+            Self::ParseProfile { path, source } => match path {
+                Some(path) => write!(f, "failed to parse profile {}: {source}", path.display()),
+                None => write!(f, "failed to parse built-in profile: {source}"),
+            },
+            Self::ValidateProfile { path, source } => match path {
+                Some(path) => write!(f, "invalid profile {}: {source}", path.display()),
+                None => write!(f, "invalid built-in profile: {source}"),
+            },
+            Self::SerializeConfig { source } => {
+                write!(
+                    f,
+                    "failed to serialize compiled config for hashing: {source}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ConfigLoadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::ReadProfile { source, .. } => Some(source),
+            Self::ParseProfile { source, .. } => Some(source),
+            Self::ValidateProfile { source, .. } => Some(source),
+            Self::SerializeConfig { source } => Some(source),
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct ControllerState {
@@ -47,9 +111,69 @@ pub struct EventBatchOutcome {
     pub rejected: u64,
 }
 
+pub fn load_profile(path: &Path) -> Result<CompiledConfig, ConfigLoadError> {
+    let content = std::fs::read_to_string(path).map_err(|source| ConfigLoadError::ReadProfile {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    compile_profile_yaml(&content, Some(path.to_path_buf()))
+}
+
+pub fn production_default_config() -> Result<CompiledConfig, ConfigLoadError> {
+    compile_profile_yaml(DEFAULT_PROFILE_YAML, None)
+}
+
+pub fn config_response_from_compiled(
+    config: CompiledConfig,
+    generation: u32,
+) -> Result<ConfigResponse, ConfigLoadError> {
+    let config_hash = config_hash(&config)?;
+    Ok(ConfigResponse {
+        wire_version: WIRE_VERSION.into(),
+        version: generation.to_string(),
+        config_hash,
+        config,
+        batching: BatchingConfig {
+            send_interval_ms: 1000,
+            max_batch_events: 256,
+        },
+    })
+}
+
+pub fn default_config_response() -> Result<ConfigResponse, ConfigLoadError> {
+    config_response_from_compiled(production_default_config()?, INITIAL_GENERATION)
+}
+
+pub fn config_hash(config: &CompiledConfig) -> Result<String, ConfigLoadError> {
+    let bytes =
+        serde_json::to_vec(config).map_err(|source| ConfigLoadError::SerializeConfig { source })?;
+    let digest = Sha256::digest(&bytes);
+    let mut hash = String::from("sha256:");
+    for byte in digest {
+        let _ = write!(&mut hash, "{byte:02x}");
+    }
+    Ok(hash)
+}
+
+fn compile_profile_yaml(
+    yaml: &str,
+    path: Option<PathBuf>,
+) -> Result<CompiledConfig, ConfigLoadError> {
+    let profile: EvidenceProfile =
+        serde_yaml::from_str(yaml).map_err(|source| ConfigLoadError::ParseProfile {
+            path: path.clone(),
+            source,
+        })?;
+    let validated = validate(&profile, &BuiltinSet::v0())
+        .map_err(|source| ConfigLoadError::ValidateProfile { path, source })?;
+    Ok(compile(&validated))
+}
+
 impl Default for ControllerState {
     fn default() -> Self {
-        Self::new(ConfigResponse::default_v1())
+        let config = default_config_response()
+            .expect("built-in production-default EvidenceProfile must compile");
+        Self::new(config)
     }
 }
 
@@ -225,11 +349,23 @@ async fn hello(
 
 async fn config(
     State(state): State<ControllerState>,
+    headers: HeaderMap,
     uri: Uri,
-) -> Result<Json<ConfigResponse>, ApiError> {
+) -> Result<Response, ApiError> {
     let agent_id = query_param(&uri, "agent_id").ok_or(WireError::MissingField("agent_id"))?;
     let node_name = query_param(&uri, "node_name").ok_or(WireError::MissingField("node_name"))?;
-    Ok(Json(state.config_for(&agent_id, &node_name)?))
+    let config = state.config_for(&agent_id, &node_name)?;
+    let etag = quoted_etag(&config.config_hash);
+
+    if if_none_match_matches(&headers, &etag) {
+        let mut response = StatusCode::NOT_MODIFIED.into_response();
+        insert_etag(response.headers_mut(), &etag);
+        return Ok(response);
+    }
+
+    let mut response = Json(config).into_response();
+    insert_etag(response.headers_mut(), &etag);
+    Ok(response)
 }
 
 async fn heartbeat(
@@ -328,11 +464,29 @@ fn query_param(uri: &Uri, name: &str) -> Option<String> {
     })
 }
 
+fn quoted_etag(config_hash: &str) -> String {
+    format!("\"{config_hash}\"")
+}
+
+fn if_none_match_matches(headers: &HeaderMap, etag: &str) -> bool {
+    headers
+        .get(header::IF_NONE_MATCH)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.trim() == etag)
+}
+
+fn insert_etag(headers: &mut HeaderMap, etag: &str) {
+    if let Ok(value) = HeaderValue::from_str(etag) {
+        headers.insert(header::ETAG, value);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::io::{Read, Write};
     use std::net::TcpStream;
+    use std::path::Path;
     use tapio_wire::{EventSeverity, HeartbeatCounters, ObserverStatus, WIRE_VERSION, WireEvent};
 
     fn hello_req() -> HelloRequest {
@@ -386,12 +540,128 @@ mod tests {
         }
     }
 
+    fn write_temp_profile(name: &str, content: &str) -> PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "tapio-{name}-{}-{}.yaml",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::write(&path, content).unwrap();
+        path
+    }
+
+    fn remove_temp_profile(path: &Path) {
+        let _ = std::fs::remove_file(path);
+    }
+
     #[test]
     fn hello_registers_agent() {
         let state = ControllerState::default();
         let response = state.register_agent(hello_req()).unwrap();
         assert!(response.accepted);
         assert_eq!(state.agent_count(), 1);
+    }
+
+    #[test]
+    fn default_controller_config_is_hashed_production_default() {
+        let state = ControllerState::default();
+        let config = state.config_for("node/worker-1", "worker-1").unwrap();
+        let expected = config_hash(&production_default_config().unwrap()).unwrap();
+        assert_eq!(config.version, "1");
+        assert_eq!(config.config_hash, expected);
+        assert!(config.config_hash.starts_with("sha256:"));
+    }
+
+    #[test]
+    fn valid_profile_loads_and_compiles() {
+        let path = write_temp_profile(
+            "valid-profile",
+            r#"
+apiVersion: tapio.false.systems/v0
+kind: EvidenceProfile
+base: production-default
+overrides:
+  storage:
+    slow_io:
+      warning_ms: 150
+      critical_ms: 400
+"#,
+        );
+
+        let compiled = load_profile(&path).unwrap();
+        remove_temp_profile(&path);
+        assert_eq!(compiled.storage.slow_io_warning_ns, 150_000_000);
+        assert_eq!(compiled.storage.slow_io_critical_ns, 400_000_000);
+    }
+
+    #[test]
+    fn invalid_profile_range_error_includes_field_path() {
+        let path = write_temp_profile(
+            "bad-range",
+            r#"
+apiVersion: tapio.false.systems/v0
+kind: EvidenceProfile
+base: production-default
+overrides:
+  storage:
+    slow_io:
+      warning_ms: 0
+"#,
+        );
+
+        let error = load_profile(&path).unwrap_err().to_string();
+        remove_temp_profile(&path);
+        assert!(error.contains("overrides.storage.slow_io.warning_ms"));
+    }
+
+    #[test]
+    fn unknown_field_profile_error_includes_field_name() {
+        let path = write_temp_profile(
+            "unknown-field",
+            r#"
+apiVersion: tapio.false.systems/v0
+kind: EvidenceProfile
+base: production-default
+surprise: true
+"#,
+        );
+
+        let error = load_profile(&path).unwrap_err().to_string();
+        remove_temp_profile(&path);
+        assert!(error.contains("surprise"));
+    }
+
+    #[test]
+    fn unknown_base_profile_error_includes_field_path() {
+        let path = write_temp_profile(
+            "unknown-base",
+            r#"
+apiVersion: tapio.false.systems/v0
+kind: EvidenceProfile
+base: staging
+"#,
+        );
+
+        let error = load_profile(&path).unwrap_err().to_string();
+        remove_temp_profile(&path);
+        assert!(error.contains("base"));
+        assert!(error.contains("staging"));
+    }
+
+    #[test]
+    fn config_hash_is_stable_and_changes_with_profile_content() {
+        let first = default_config_response().unwrap();
+        let second = default_config_response().unwrap();
+        assert_eq!(first.config_hash, second.config_hash);
+
+        let mut changed = production_default_config().unwrap();
+        changed.storage.slow_io_warning_ns = 150_000_000;
+        let changed = config_response_from_compiled(changed, 1).unwrap();
+        assert_ne!(first.config_hash, changed.config_hash);
     }
 
     #[test]
@@ -484,6 +754,10 @@ mod tests {
     }
 
     async fn http_response(request: &str) -> Option<String> {
+        http_response_with_state(request, ControllerState::default()).await
+    }
+
+    async fn http_response_with_state(request: &str, state: ControllerState) -> Option<String> {
         let require_net = std::env::var_os("TAPIO_LEAN_REQUIRE_NET").is_some();
         let listener = match tokio::net::TcpListener::bind("127.0.0.1:0").await {
             Ok(listener) => listener,
@@ -497,7 +771,7 @@ mod tests {
             Err(e) => panic!("loopback bind failed: {e}"),
         };
         let addr = listener.local_addr().unwrap();
-        let app = router(ControllerState::default());
+        let app = router(state);
         let server = tokio::spawn(async move {
             axum::serve(listener, app).await.unwrap();
         });
@@ -520,6 +794,10 @@ mod tests {
     fn response_json(response: &str) -> serde_json::Value {
         let (_, body) = response.split_once("\r\n\r\n").unwrap();
         serde_json::from_str(body).unwrap()
+    }
+
+    fn response_body(response: &str) -> &str {
+        response.split_once("\r\n\r\n").map_or("", |(_, body)| body)
     }
 
     #[tokio::test]
@@ -580,5 +858,59 @@ mod tests {
         let body = response_json(&response);
         assert_eq!(body["error"]["code"], "MISSING_FIELD");
         assert_eq!(body["error"]["message"], "agent_id is required");
+    }
+
+    #[tokio::test]
+    async fn config_endpoint_returns_etag_and_hash() {
+        let state = ControllerState::default();
+        let expected = state.config_for("node/worker-1", "worker-1").unwrap();
+        let Some(response) = http_response_with_state(
+            "GET /v1/agents/config?agent_id=node/worker-1&node_name=worker-1 HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+            state,
+        )
+        .await
+        else {
+            return;
+        };
+
+        assert!(response.starts_with("HTTP/1.1 200"));
+        assert!(response.contains(&format!("etag: \"{}\"", expected.config_hash)));
+        let body = response_json(&response);
+        assert_eq!(body["config_hash"], expected.config_hash);
+    }
+
+    #[tokio::test]
+    async fn config_endpoint_returns_304_for_matching_if_none_match() {
+        let state = ControllerState::default();
+        let expected = state.config_for("node/worker-1", "worker-1").unwrap();
+        let request = format!(
+            "GET /v1/agents/config?agent_id=node/worker-1&node_name=worker-1 HTTP/1.1\r\nHost: localhost\r\nIf-None-Match: \"{}\"\r\nConnection: close\r\n\r\n",
+            expected.config_hash
+        );
+        let Some(response) = http_response_with_state(&request, state).await else {
+            return;
+        };
+
+        assert!(response.starts_with("HTTP/1.1 304"));
+        assert!(response.contains(&format!("etag: \"{}\"", expected.config_hash)));
+        assert_eq!(response_body(&response), "");
+    }
+
+    #[tokio::test]
+    async fn config_endpoint_returns_200_for_stale_if_none_match() {
+        let state = ControllerState::default();
+        let expected = state.config_for("node/worker-1", "worker-1").unwrap();
+        let Some(response) = http_response_with_state(
+            "GET /v1/agents/config?agent_id=node/worker-1&node_name=worker-1 HTTP/1.1\r\nHost: localhost\r\nIf-None-Match: \"sha256:stale\"\r\nConnection: close\r\n\r\n",
+            state,
+        )
+        .await
+        else {
+            return;
+        };
+
+        assert!(response.starts_with("HTTP/1.1 200"));
+        let body = response_json(&response);
+        assert_eq!(body["config_hash"], expected.config_hash);
     }
 }

--- a/tapio-controller/src/main.rs
+++ b/tapio-controller/src/main.rs
@@ -1,6 +1,15 @@
 use std::net::SocketAddr;
+use std::path::PathBuf;
 
-use tapio_controller::{ControllerState, router};
+use tapio_controller::{
+    ControllerState, config_response_from_compiled, default_config_response, load_profile, router,
+};
+
+#[derive(Debug)]
+struct Args {
+    addr: SocketAddr,
+    profile: Option<PathBuf>,
+}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -8,14 +17,41 @@ async fn main() -> anyhow::Result<()> {
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
 
-    let addr = std::env::args()
-        .nth(1)
-        .unwrap_or_else(|| "127.0.0.1:8080".into())
-        .parse::<SocketAddr>()?;
+    let args = parse_args(std::env::args().skip(1))?;
+    let config = match &args.profile {
+        Some(path) => config_response_from_compiled(load_profile(path)?, 1)?,
+        None => default_config_response()?,
+    };
 
-    let state = ControllerState::default();
-    tracing::info!(%addr, "tapio-controller starting");
-    let listener = tokio::net::TcpListener::bind(addr).await?;
+    let state = ControllerState::new(config);
+    tracing::info!(addr = %args.addr, "tapio-controller starting");
+    let listener = tokio::net::TcpListener::bind(args.addr).await?;
     axum::serve(listener, router(state)).await?;
     Ok(())
+}
+
+fn parse_args(args: impl IntoIterator<Item = String>) -> anyhow::Result<Args> {
+    let mut addr = None;
+    let mut profile = None;
+    let mut iter = args.into_iter();
+
+    while let Some(arg) = iter.next() {
+        if arg == "--profile" {
+            let path = iter
+                .next()
+                .ok_or_else(|| anyhow::anyhow!("--profile requires a path"))?;
+            if profile.replace(PathBuf::from(path)).is_some() {
+                anyhow::bail!("--profile may be provided at most once in v0");
+            }
+        } else if arg.starts_with("--") {
+            anyhow::bail!("unknown argument {arg}");
+        } else if addr.replace(arg.parse::<SocketAddr>()?).is_some() {
+            anyhow::bail!("controller address may be provided at most once");
+        }
+    }
+
+    Ok(Args {
+        addr: addr.unwrap_or_else(|| SocketAddr::from(([127, 0, 0, 1], 8080))),
+        profile,
+    })
 }

--- a/tapio-wire/src/lib.rs
+++ b/tapio-wire/src/lib.rs
@@ -56,6 +56,8 @@ pub struct HelloResponse {
 pub struct ConfigResponse {
     pub wire_version: String,
     pub version: String,
+    #[serde(default)]
+    pub config_hash: String,
     pub config: CompiledConfig,
     pub batching: BatchingConfig,
 }
@@ -188,6 +190,7 @@ impl ConfigResponse {
         Self {
             wire_version: WIRE_VERSION.into(),
             version: "1".into(),
+            config_hash: String::new(),
             config: CompiledConfig {
                 network: CompiledNetwork {
                     enabled: true,
@@ -477,9 +480,47 @@ mod tests {
 
     #[test]
     fn config_round_trip_and_validate() {
-        let config = ConfigResponse::default_v1();
+        let mut config = ConfigResponse::default_v1();
+        config.config_hash = "sha256:abc123".into();
         let json = serde_json::to_string(&config).unwrap();
         let parsed: ConfigResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.config_hash, "sha256:abc123");
+        parsed.validate().unwrap();
+    }
+
+    #[test]
+    fn config_response_without_hash_still_deserializes() {
+        let parsed: ConfigResponse = serde_json::from_str(
+            r#"{
+              "wire_version":"tapio-wire/v1",
+              "version":"1",
+              "config":{
+                "network":{
+                  "enabled":true,
+                  "rtt_spike_ratio":2,
+                  "rtt_spike_abs_us":500000,
+                  "rtt_min_baseline_samples":5,
+                  "conn_refused_window_ns":0,
+                  "conn_refused_min_count":0
+                },
+                "storage":{
+                  "enabled":true,
+                  "slow_io_warning_ns":50000000,
+                  "slow_io_critical_ns":200000000
+                },
+                "container":{"enabled":true,"ignore_exit_codes":[]},
+                "node_pmc":{
+                  "enabled":true,
+                  "stall_warning_permille":200,
+                  "stall_critical_permille":400,
+                  "ipc_degradation_milli":1000
+                }
+              },
+              "batching":{"send_interval_ms":1000,"max_batch_events":256}
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(parsed.config_hash, "");
         parsed.validate().unwrap();
     }
 


### PR DESCRIPTION
## Scope
PR 2 from docs/config-distribution-mega-prompt.md: controller distributes compiled config with generation/hash and ETag caching.

Base: updated main after PR #650 merged.

## Public API / wire changes
- ConfigResponse gains additive serde-default config_hash: String.
- Old payloads without config_hash still deserialize and validate.
- Controller exposes load_profile(path) -> Result<CompiledConfig, ConfigLoadError>, production_default_config(), config_hash(), and config_response_from_compiled().
- GET /v1/agents/config now returns ETag: "<config_hash>" and honors If-None-Match with 304 Not Modified and no body.

## Controller behavior
- tapio-controller accepts --profile <path> exactly once in v0.
- With --profile, the controller reads EvidenceProfile YAML, deserializes with serde_yaml, validates with tapio-profile BuiltinSet::v0(), compiles, hashes, and serves it as generation 1.
- Without --profile, the controller compiles the minimal production-default EvidenceProfile through tapio-profile and serves those same bytes as generation 1.
- Profile parse/validation/read errors are startup failures; ProfileError Display keeps field paths in the error text.

## Dependencies
- tapio-controller only: tapio-profile, serde_yaml 0.9, sha2 0.10.
- serde_yaml is startup-only on operator-trusted input and documented as archived/replaceable behind Deserialize in docs/wire-api-standard.md.
- Dependency boundary script now forbids tapio-profile, serde_yaml, and sha2 in tapio-agent and tapio-cli.
- No agent dependency changes.

## Tests / gates
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- scripts/check-dependency-boundaries.sh
- ./scripts/verify-lean.sh

## Test counts
- tapio-controller: 19 unit tests
- tapio-wire: 14 unit tests
- workspace tests: all passing, including 38 tapio-profile tests and doctest

## Binary / budget results
- local macOS verify-lean after unsandboxed loopback access: tapio-agent 654,720 bytes, under 1,250,000 target; tapio CLI 704,512 bytes, under 900,000 hard limit; tapio-controller 1,155,072 bytes reported only
- eBPF map budgets unchanged and passing
- local eBPF compile skipped because /usr/include/bpf/bpf_helpers.h is unavailable
- no Linux runtime smoke is required for PR 2

## Refusals touched
- no SIGHUP/file-watch reload; controller restart is the v0 config-change mechanism
- no profile CRUD API and no POST /v1/profiles
- no per-node config variation; agent_id/node_name are validated but do not change config selection
- no controller persistence; generation/hash are in-memory startup state
- no agent polling or status echo in this PR

## Notes
- docs/config-distribution-mega-prompt.md is a local prompt artifact and intentionally not included.