### PR TITLE
feat(agent): poll compiled config and apply it live

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,8 @@ The `tapio-agent` binary accepts:
 - `--ebpf-dir <path>` — directory with compiled `.o` files (default: `/opt/tapio/ebpf`)
 - `--data-dir <path>` — directory for file sink output (default: `.tapio/occurrences`)
 - `--http-endpoint <url>` — endpoint for the `http` sink (default: `http://localhost:8765`)
+- `--controller-endpoint <url>` — controller base URL for compiled config polling (`http://` only; absent means standalone TOML mode)
+- `--config-poll-interval <seconds>` — controller config polling interval, minimum 5 seconds (default: `30`)
 
 ## Environment variables
 
@@ -135,4 +137,5 @@ The `tapio-agent` binary accepts:
 - **Logging**: `tracing` crate, env-filtered via `RUST_LOG`
 - **Metrics**: `prometheus` crate on configurable port (default `:9090`) via a tiny local HTTP handler. Enable with `[metrics] enabled = true` in config. **Binds to `127.0.0.1` by default** — set `bind_address = "0.0.0.0"` to expose to the node network (e.g. for cluster Prometheus scrape). Families: `tapio_events_total`, `tapio_anomalies_total`, `tapio_lost_events_total`, `tapio_malformed_events_total`, `tapio_drain_cap_total`, `tapio_sink_writes_total`
 - **Metric prefix**: `tapio_`
+- **Controller config metric**: `tapio_config_fetch_total{result="applied|not_modified|error|rejected"}` counts controller-mode config poll outcomes.
 - **eBPF-side metrics**: the shared per-CPU `tapio_metrics` map currently exports only `METRIC_LOST_EVENTS` to userspace. Do not add counters to `metrics.h` unless userspace reads and exposes them or the counter is otherwise consumed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,6 +1014,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tapio-common",
+ "tapio-wire",
  "tokio",
  "toml",
  "tracing",

--- a/scripts/smoke-ebpf-controller-config.sh
+++ b/scripts/smoke-ebpf-controller-config.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_DIR="${OUT_DIR:-/tmp/tapio-smoke-controller}"
+EBPF_ARCH="${EBPF_ARCH:-}"
+PORT="${PORT:-$((40000 + ($$ % 20000)))}"
+CONTROLLER_PORT="${CONTROLLER_PORT:-$((20000 + ($$ % 20000)))}"
+CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$OUT_DIR/target}"
+export CARGO_TARGET_DIR
+
+cd "$ROOT"
+
+section() {
+  printf '\n==> %s\n' "$1"
+}
+
+detect_bpf_arch() {
+  if [[ -n "$EBPF_ARCH" ]]; then
+    printf '%s\n' "$EBPF_ARCH"
+    return
+  fi
+
+  case "$(uname -m)" in
+    arm64|aarch64) printf 'arm64\n' ;;
+    x86_64|amd64) printf 'x86\n' ;;
+    *) printf 'x86\n' ;;
+  esac
+}
+
+cleanup() {
+  if [[ -n "${agent_pid:-}" ]] && kill -0 "$agent_pid" 2>/dev/null; then
+    sudo kill "$agent_pid" 2>/dev/null || true
+    wait "$agent_pid" 2>/dev/null || true
+  fi
+  if [[ -n "${controller_pid:-}" ]] && kill -0 "$controller_pid" 2>/dev/null; then
+    kill "$controller_pid" 2>/dev/null || true
+    wait "$controller_pid" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  printf 'controller config eBPF smoke test requires Linux\n' >&2
+  exit 2
+fi
+
+if ! command -v clang >/dev/null 2>&1; then
+  printf 'clang is required for eBPF smoke test\n' >&2
+  exit 2
+fi
+
+if [[ ! -r /usr/include/bpf/bpf_helpers.h ]]; then
+  printf '/usr/include/bpf/bpf_helpers.h is required for eBPF smoke test\n' >&2
+  exit 2
+fi
+
+section "Environment"
+uname -a
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR/ebpf" "$OUT_DIR/data" "$OUT_DIR/log"
+
+cat >"$OUT_DIR/profile.yaml" <<'YAML'
+apiVersion: tapio.false.systems/v0
+kind: EvidenceProfile
+base: production-default
+overrides:
+  network:
+    rtt_spike:
+      ratio: 3
+      abs_ms: 250
+YAML
+
+section "Build"
+cargo build --release -p tapio-agent -p tapio-controller
+
+bpf_arch="$(detect_bpf_arch)"
+for prog in network_monitor container_monitor storage_monitor node_pmc_monitor; do
+  clang -O2 -g -target bpf "-D__TARGET_ARCH_${bpf_arch}" \
+    -I ebpf/headers \
+    -c "ebpf/${prog}.c" \
+    -o "$OUT_DIR/ebpf/${prog}.o"
+done
+
+section "Start controller"
+RUST_LOG=tapio_controller=info \
+  "$CARGO_TARGET_DIR/release/tapio-controller" \
+  "127.0.0.1:${CONTROLLER_PORT}" \
+  --profile "$OUT_DIR/profile.yaml" \
+  >"$OUT_DIR/log/controller.stdout" \
+  2>"$OUT_DIR/log/controller.stderr" &
+controller_pid="$!"
+
+for _ in $(seq 1 100); do
+  if grep -q 'tapio-controller starting' "$OUT_DIR/log/controller.stderr"; then
+    break
+  fi
+  if ! kill -0 "$controller_pid" 2>/dev/null; then
+    printf 'controller exited before startup\n' >&2
+    cat "$OUT_DIR/log/controller.stderr" >&2
+    exit 1
+  fi
+  sleep 0.1
+done
+
+section "Start agent in controller mode"
+sudo env RUST_LOG=tapio_agent=info \
+  "$CARGO_TARGET_DIR/release/tapio-agent" \
+  --sink file \
+  --data-dir "$OUT_DIR/data" \
+  --ebpf-dir "$OUT_DIR/ebpf" \
+  --controller-endpoint "http://127.0.0.1:${CONTROLLER_PORT}" \
+  --config-poll-interval 5 \
+  >"$OUT_DIR/log/agent.stdout" \
+  2>"$OUT_DIR/log/agent.stderr" &
+agent_pid="$!"
+
+for _ in $(seq 1 100); do
+  if grep -q 'config applied' "$OUT_DIR/log/agent.stderr"; then
+    break
+  fi
+  if ! kill -0 "$agent_pid" 2>/dev/null; then
+    printf 'agent exited before config applied\n' >&2
+    cat "$OUT_DIR/log/agent.stderr" >&2
+    exit 1
+  fi
+  sleep 0.1
+done
+
+if ! grep -q 'config applied' "$OUT_DIR/log/agent.stderr"; then
+  printf 'agent did not apply controller config\n' >&2
+  cat "$OUT_DIR/log/agent.stderr" >&2
+  exit 1
+fi
+
+section "Trigger closed-port TCP connect"
+for _ in $(seq 1 5); do
+  timeout 1 bash -c ":</dev/tcp/127.0.0.1/${PORT}" >/dev/null 2>&1 || true
+  sleep 0.1
+done
+
+section "Assert occurrence generation"
+for _ in $(seq 1 100); do
+  if grep -R -E -q "\"dst_port\": *${PORT}" "$OUT_DIR/data" &&
+     grep -R -E -q '"config_generation": *1' "$OUT_DIR/data"; then
+    printf 'observed controller-configured network occurrence for dst_port=%s generation=1\n' "$PORT"
+    grep -R -E '"type":"kernel.network.|"dst_port":|"config_generation":' "$OUT_DIR/data" | head -n 12
+    exit 0
+  fi
+  sleep 0.1
+done
+
+printf 'no controller-configured network occurrence with dst_port=%s generation=1 observed\n' "$PORT" >&2
+printf '\ncontroller stderr:\n' >&2
+cat "$OUT_DIR/log/controller.stderr" >&2
+printf '\nagent stderr:\n' >&2
+cat "$OUT_DIR/log/agent.stderr" >&2
+printf '\noccurrences:\n' >&2
+find "$OUT_DIR/data" -maxdepth 1 -type f | head -n 8 | while read -r file; do
+  printf '%s\n' "$file" >&2
+  cat "$file" >&2
+done
+exit 1

--- a/tapio-agent/Cargo.toml
+++ b/tapio-agent/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 tapio-common = { workspace = true }
+tapio-wire = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/tapio-agent/src/config.rs
+++ b/tapio-agent/src/config.rs
@@ -158,14 +158,6 @@ impl Thresholds {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-pub struct PmcThresholds {
-    pub stall_pct_warning: f64,
-    pub stall_pct_critical: f64,
-    pub ipc_degradation: f64,
-}
-
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub enum CompiledConfigError {
@@ -242,8 +234,10 @@ pub fn tapio_config_from_compiled(
 }
 
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-pub fn pmc_thresholds_from_compiled(config: &CompiledConfig) -> PmcThresholds {
-    PmcThresholds {
+pub fn pmc_thresholds_from_compiled(
+    config: &CompiledConfig,
+) -> crate::observer::node_pmc::PmcThresholds {
+    crate::observer::node_pmc::PmcThresholds {
         stall_pct_warning: config.node_pmc.stall_warning_permille as f64 / 10.0,
         stall_pct_critical: config.node_pmc.stall_critical_permille as f64 / 10.0,
         ipc_degradation: config.node_pmc.ipc_degradation_milli as f64 / 1000.0,

--- a/tapio-agent/src/config.rs
+++ b/tapio-agent/src/config.rs
@@ -4,6 +4,7 @@ use tapio_common::ebpf::{
     TAPIO_CONFIG_ABI_VERSION, TAPIO_F_CONTAINER, TAPIO_F_NETWORK, TAPIO_F_NODE_PMC,
     TAPIO_F_STORAGE, TapioConfig,
 };
+use tapio_wire::CompiledConfig;
 
 /// Agent configuration loaded from TOML file.
 /// CLI flags take precedence — fields here are all optional so missing values
@@ -154,6 +155,98 @@ impl Thresholds {
             ignore_exit_codes,
             _pad: 0,
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub struct PmcThresholds {
+    pub stall_pct_warning: f64,
+    pub stall_pct_critical: f64,
+    pub ipc_degradation: f64,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub enum CompiledConfigError {
+    InvalidGeneration { value: String },
+}
+
+impl std::fmt::Display for CompiledConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidGeneration { value } => {
+                write!(f, "config version {value:?} is not a valid u32 generation")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CompiledConfigError {}
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub fn tapio_config_from_compiled(
+    config: &CompiledConfig,
+    generation: &str,
+) -> Result<TapioConfig, CompiledConfigError> {
+    let generation =
+        generation
+            .parse::<u32>()
+            .map_err(|_| CompiledConfigError::InvalidGeneration {
+                value: generation.to_string(),
+            })?;
+
+    let mut flags = 0;
+    if config.network.enabled {
+        flags |= TAPIO_F_NETWORK;
+    }
+    if config.storage.enabled {
+        flags |= TAPIO_F_STORAGE;
+    }
+    if config.container.enabled {
+        flags |= TAPIO_F_CONTAINER;
+    }
+    if config.node_pmc.enabled {
+        flags |= TAPIO_F_NODE_PMC;
+    }
+
+    let mut ignore_exit_codes = [0; tapio_common::ebpf::TAPIO_CONFIG_MAX_IGNORE_EXIT_CODES];
+    for (slot, code) in ignore_exit_codes
+        .iter_mut()
+        .zip(config.container.ignore_exit_codes.iter())
+    {
+        *slot = *code;
+    }
+    let ignore_exit_count = config
+        .container
+        .ignore_exit_codes
+        .len()
+        .min(tapio_common::ebpf::TAPIO_CONFIG_MAX_IGNORE_EXIT_CODES)
+        as u32;
+
+    Ok(TapioConfig {
+        abi_version: TAPIO_CONFIG_ABI_VERSION,
+        generation,
+        flags,
+        slow_io_threshold_ns: config.storage.slow_io_warning_ns,
+        io_latency_critical_ns: config.storage.slow_io_critical_ns,
+        conn_refused_window_ns: config.network.conn_refused_window_ns,
+        conn_refused_min_count: config.network.conn_refused_min_count,
+        rtt_spike_multiplier: config.network.rtt_spike_ratio,
+        rtt_spike_abs_us: config.network.rtt_spike_abs_us,
+        rtt_min_baseline_samples: config.network.rtt_min_baseline_samples,
+        ignore_exit_count,
+        ignore_exit_codes,
+        _pad: 0,
+    })
+}
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub fn pmc_thresholds_from_compiled(config: &CompiledConfig) -> PmcThresholds {
+    PmcThresholds {
+        stall_pct_warning: config.node_pmc.stall_warning_permille as f64 / 10.0,
+        stall_pct_critical: config.node_pmc.stall_critical_permille as f64 / 10.0,
+        ipc_degradation: config.node_pmc.ipc_degradation_milli as f64 / 1000.0,
     }
 }
 
@@ -316,5 +409,84 @@ mod tests {
         let config = Config::default().tapio_config();
         assert_eq!(config.ignore_exit_count, 0);
         assert!(config.ignore_exit_count as usize <= config.ignore_exit_codes.len());
+    }
+
+    fn compiled_config() -> CompiledConfig {
+        CompiledConfig {
+            network: tapio_wire::CompiledNetwork {
+                enabled: true,
+                rtt_spike_ratio: 3,
+                rtt_spike_abs_us: 250_000,
+                rtt_min_baseline_samples: 7,
+                conn_refused_window_ns: 1_000_000_000,
+                conn_refused_min_count: 4,
+            },
+            storage: tapio_wire::CompiledStorage {
+                enabled: true,
+                slow_io_warning_ns: 150_000_000,
+                slow_io_critical_ns: 400_000_000,
+            },
+            container: tapio_wire::CompiledContainer {
+                enabled: true,
+                ignore_exit_codes: vec![0, 143],
+            },
+            node_pmc: tapio_wire::CompiledNodePmc {
+                enabled: false,
+                stall_warning_permille: 250,
+                stall_critical_permille: 500,
+                ipc_degradation_milli: 800,
+            },
+        }
+    }
+
+    #[test]
+    fn compiled_config_maps_to_tapio_config_fields() {
+        let config = tapio_config_from_compiled(&compiled_config(), "17").unwrap();
+        assert_eq!(config.abi_version, TAPIO_CONFIG_ABI_VERSION);
+        assert_eq!(config.generation, 17);
+        assert_eq!(
+            config.flags,
+            TAPIO_F_NETWORK | TAPIO_F_STORAGE | TAPIO_F_CONTAINER
+        );
+        assert_eq!(config.rtt_spike_multiplier, 3);
+        assert_eq!(config.rtt_spike_abs_us, 250_000);
+        assert_eq!(config.rtt_min_baseline_samples, 7);
+        assert_eq!(config.conn_refused_window_ns, 1_000_000_000);
+        assert_eq!(config.conn_refused_min_count, 4);
+        assert_eq!(config.slow_io_threshold_ns, 150_000_000);
+        assert_eq!(config.io_latency_critical_ns, 400_000_000);
+        assert_eq!(config.ignore_exit_count, 2);
+        assert_eq!(config.ignore_exit_codes[0], 0);
+        assert_eq!(config.ignore_exit_codes[1], 143);
+    }
+
+    #[test]
+    fn compiled_config_rejects_invalid_generation() {
+        assert_eq!(
+            tapio_config_from_compiled(&compiled_config(), "not-a-number").unwrap_err(),
+            CompiledConfigError::InvalidGeneration {
+                value: "not-a-number".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn compiled_config_truncates_ignore_exit_codes_to_abi_bound() {
+        let mut compiled = compiled_config();
+        compiled.container.ignore_exit_codes = (0..32).collect();
+        let config = tapio_config_from_compiled(&compiled, "1").unwrap();
+        assert_eq!(
+            config.ignore_exit_count as usize,
+            tapio_common::ebpf::TAPIO_CONFIG_MAX_IGNORE_EXIT_CODES
+        );
+        assert_eq!(config.ignore_exit_codes[15], 15);
+    }
+
+    #[test]
+    fn compiled_config_maps_pmc_thresholds_to_f64() {
+        let thresholds = pmc_thresholds_from_compiled(&compiled_config());
+        assert_eq!(thresholds.stall_pct_warning, 25.0);
+        assert_eq!(thresholds.stall_pct_critical, 50.0);
+        assert_eq!(thresholds.ipc_degradation, 0.8);
     }
 }

--- a/tapio-agent/src/controller.rs
+++ b/tapio-agent/src/controller.rs
@@ -1,0 +1,208 @@
+use std::time::Duration;
+
+#[cfg(target_os = "linux")]
+use tapio_common::ebpf::TapioConfig;
+#[cfg(target_os = "linux")]
+use tapio_wire::ConfigResponse;
+
+#[cfg(target_os = "linux")]
+use crate::observer::ConfigCarriers;
+
+#[derive(Debug, Clone)]
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub struct ControllerConfig {
+    pub endpoint: String,
+    pub agent_id: String,
+    pub node_name: String,
+    pub poll_interval: Duration,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub enum PollOutcome {
+    Applied { generation: u32, hash: String },
+    NotModified,
+}
+
+#[cfg(target_os = "linux")]
+pub async fn poll_loop(
+    controller: ControllerConfig,
+    carriers: ConfigCarriers,
+    pmc_thresholds_tx: tokio::sync::watch::Sender<crate::observer::node_pmc::PmcThresholds>,
+    metrics: crate::metrics::TapioMetrics,
+    mut shutdown: tokio::sync::watch::Receiver<bool>,
+) {
+    let mut etag: Option<String> = None;
+    tracing::info!(
+        endpoint = %controller.endpoint,
+        interval_secs = controller.poll_interval.as_secs(),
+        "config poll start"
+    );
+    let mut interval = tokio::time::interval(controller.poll_interval);
+
+    loop {
+        tokio::select! {
+            _ = shutdown.changed() => {
+                tracing::info!("config poll stop");
+                break;
+            }
+            _ = interval.tick() => {
+                match fetch_once(&controller, etag.as_deref(), &carriers, &pmc_thresholds_tx).await {
+                    Ok(PollOutcome::Applied { generation, hash }) => {
+                        etag = Some(format!("\"{hash}\""));
+                        let label = "applied";
+                        metrics.config_fetch_total.with_label_values(&[label]).inc();
+                        tracing::info!(generation, hash = %hash, "config applied");
+                    }
+                    Ok(PollOutcome::NotModified) => {
+                        metrics.config_fetch_total.with_label_values(&["not_modified"]).inc();
+                    }
+                    Err(FetchError::Rejected(error)) => {
+                        metrics.config_fetch_total.with_label_values(&["rejected"]).inc();
+                        tracing::warn!(error = %error, "config rejected");
+                    }
+                    Err(FetchError::Transport(error)) => {
+                        metrics.config_fetch_total.with_label_values(&["error"]).inc();
+                        tracing::warn!(error = %error, "config fetch failed");
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+async fn fetch_once(
+    controller: &ControllerConfig,
+    etag: Option<&str>,
+    carriers: &ConfigCarriers,
+    pmc_thresholds_tx: &tokio::sync::watch::Sender<crate::observer::node_pmc::PmcThresholds>,
+) -> Result<PollOutcome, FetchError> {
+    let url = config_url(controller);
+    let mut headers = Vec::new();
+    if let Some(etag) = etag {
+        headers.push(("If-None-Match", etag.to_string()));
+    }
+    let response = tokio::task::spawn_blocking(move || {
+        crate::httpc::get(
+            &url,
+            &headers,
+            crate::httpc::DEFAULT_TIMEOUT,
+            crate::httpc::DEFAULT_MAX_RESPONSE_BYTES,
+        )
+    })
+    .await
+    .map_err(|e| FetchError::Transport(format!("join fetch: {e}")))?
+    .map_err(FetchError::Transport)?;
+    let _response_etag = response.etag.as_deref();
+
+    match response.status {
+        304 => Ok(PollOutcome::NotModified),
+        200 => {
+            let config: ConfigResponse = serde_json::from_slice(&response.body)
+                .map_err(|e| FetchError::Rejected(format!("decode ConfigResponse: {e}")))?;
+            let generation = config.version.parse::<u32>().map_err(|_| {
+                FetchError::Rejected(format!("bad config version {:?}", config.version))
+            })?;
+            config
+                .validate()
+                .map_err(|e| FetchError::Rejected(e.to_string()))?;
+            let tapio_config =
+                crate::config::tapio_config_from_compiled(&config.config, &config.version)
+                    .map_err(|e| FetchError::Rejected(e.to_string()))?;
+            apply_config(carriers, pmc_thresholds_tx, &tapio_config, &config.config)?;
+            Ok(PollOutcome::Applied {
+                generation,
+                hash: config.config_hash,
+            })
+        }
+        status => Err(FetchError::Transport(format!("HTTP {status}"))),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn apply_config(
+    carriers: &ConfigCarriers,
+    pmc_thresholds_tx: &tokio::sync::watch::Sender<crate::observer::node_pmc::PmcThresholds>,
+    tapio_config: &TapioConfig,
+    compiled: &tapio_wire::CompiledConfig,
+) -> Result<(), FetchError> {
+    let failed = carriers.update_all(tapio_config);
+    if !failed.is_empty() {
+        tracing::warn!(failed = ?failed, "partial config fan-out");
+    }
+    let thresholds = crate::config::pmc_thresholds_from_compiled(compiled);
+    pmc_thresholds_tx
+        .send(crate::observer::node_pmc::PmcThresholds {
+            stall_pct_warning: thresholds.stall_pct_warning,
+            stall_pct_critical: thresholds.stall_pct_critical,
+            ipc_degradation: thresholds.ipc_degradation,
+        })
+        .map_err(|e| FetchError::Transport(format!("PMC thresholds: {e}")))?;
+    Ok(())
+}
+
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub enum FetchError {
+    Transport(String),
+    Rejected(String),
+}
+
+impl std::fmt::Display for FetchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Transport(error) | Self::Rejected(error) => f.write_str(error),
+        }
+    }
+}
+
+impl std::error::Error for FetchError {}
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub fn config_url(controller: &ControllerConfig) -> String {
+    format!(
+        "{}/v1/agents/config?agent_id={}&node_name={}",
+        controller.endpoint.trim_end_matches('/'),
+        url_component(&controller.agent_id),
+        url_component(&controller.node_name)
+    )
+}
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn url_component(value: &str) -> String {
+    let mut out = String::new();
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char)
+            }
+            other => {
+                out.push('%');
+                out.push(HEX[(other >> 4) as usize] as char);
+                out.push(HEX[(other & 0x0f) as usize] as char);
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_url_encodes_agent_and_node() {
+        let controller = ControllerConfig {
+            endpoint: "http://controller:8080/".into(),
+            agent_id: "node/worker 1".into(),
+            node_name: "worker/1".into(),
+            poll_interval: Duration::from_secs(30),
+        };
+        assert_eq!(
+            config_url(&controller),
+            "http://controller:8080/v1/agents/config?agent_id=node%2Fworker%201&node_name=worker%2F1"
+        );
+    }
+}

--- a/tapio-agent/src/controller.rs
+++ b/tapio-agent/src/controller.rs
@@ -94,7 +94,6 @@ async fn fetch_once(
     .await
     .map_err(|e| FetchError::Transport(format!("join fetch: {e}")))?
     .map_err(FetchError::Transport)?;
-    let _response_etag = response.etag.as_deref();
 
     match response.status {
         304 => Ok(PollOutcome::NotModified),
@@ -107,6 +106,7 @@ async fn fetch_once(
             config
                 .validate()
                 .map_err(|e| FetchError::Rejected(e.to_string()))?;
+            reject_empty_config_hash(&config.config_hash)?;
             let tapio_config =
                 crate::config::tapio_config_from_compiled(&config.config, &config.version)
                     .map_err(|e| FetchError::Rejected(e.to_string()))?;
@@ -120,6 +120,17 @@ async fn fetch_once(
     }
 }
 
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn reject_empty_config_hash(hash: &str) -> Result<(), FetchError> {
+    if hash.is_empty() {
+        return Err(FetchError::Rejected(
+            "config response missing config_hash".into(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 #[cfg(target_os = "linux")]
 fn apply_config(
     carriers: &ConfigCarriers,
@@ -131,13 +142,8 @@ fn apply_config(
     if !failed.is_empty() {
         tracing::warn!(failed = ?failed, "partial config fan-out");
     }
-    let thresholds = crate::config::pmc_thresholds_from_compiled(compiled);
     pmc_thresholds_tx
-        .send(crate::observer::node_pmc::PmcThresholds {
-            stall_pct_warning: thresholds.stall_pct_warning,
-            stall_pct_critical: thresholds.stall_pct_critical,
-            ipc_degradation: thresholds.ipc_degradation,
-        })
+        .send(crate::config::pmc_thresholds_from_compiled(compiled))
         .map_err(|e| FetchError::Transport(format!("PMC thresholds: {e}")))?;
     Ok(())
 }
@@ -204,5 +210,14 @@ mod tests {
             config_url(&controller),
             "http://controller:8080/v1/agents/config?agent_id=node%2Fworker%201&node_name=worker%2F1"
         );
+    }
+
+    #[test]
+    fn empty_config_hash_is_rejected() {
+        assert_eq!(
+            reject_empty_config_hash("").unwrap_err(),
+            FetchError::Rejected("config response missing config_hash".into())
+        );
+        assert!(reject_empty_config_hash("sha256:abc").is_ok());
     }
 }

--- a/tapio-agent/src/httpc.rs
+++ b/tapio-agent/src/httpc.rs
@@ -1,0 +1,239 @@
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::time::Duration;
+
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub const DEFAULT_MAX_RESPONSE_BYTES: usize = 1024 * 1024;
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub struct HttpResponse {
+    pub status: u16,
+    pub etag: Option<String>,
+    pub body: Vec<u8>,
+}
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub fn get(
+    endpoint: &str,
+    headers: &[(&str, String)],
+    timeout: Duration,
+    max_response_bytes: usize,
+) -> Result<HttpResponse, String> {
+    request("GET", endpoint, headers, &[], timeout, max_response_bytes)
+}
+
+pub fn post_json(endpoint: &str, body: &[u8]) -> Result<(), String> {
+    let response = request(
+        "POST",
+        endpoint,
+        &[("Content-Type", "application/json".to_string())],
+        body,
+        DEFAULT_TIMEOUT,
+        256,
+    )?;
+
+    if (200..300).contains(&response.status) {
+        Ok(())
+    } else {
+        Err(format!("HTTP {}", response.status))
+    }
+}
+
+fn request(
+    method: &str,
+    endpoint: &str,
+    headers: &[(&str, String)],
+    body: &[u8],
+    timeout: Duration,
+    max_response_bytes: usize,
+) -> Result<HttpResponse, String> {
+    let url = endpoint
+        .strip_prefix("http://")
+        .ok_or_else(|| format!("requires http://: {endpoint}"))?;
+
+    let (host_port, path) = match url.find('/') {
+        Some(i) => (&url[..i], &url[i..]),
+        None if method == "POST" => (url, "/v1/occurrences"),
+        None => (url, "/"),
+    };
+
+    let mut stream = TcpStream::connect(host_port).map_err(|e| format!("connect: {e}"))?;
+    stream.set_write_timeout(Some(timeout)).ok();
+    stream.set_read_timeout(Some(timeout)).ok();
+
+    let mut request = format!("{method} {path} HTTP/1.1\r\nHost: {host_port}\r\n");
+    for (name, value) in headers {
+        request.push_str(name);
+        request.push_str(": ");
+        request.push_str(value);
+        request.push_str("\r\n");
+    }
+    if !body.is_empty() {
+        request.push_str(&format!("Content-Length: {}\r\n", body.len()));
+    }
+    request.push_str("Connection: close\r\n\r\n");
+
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|e| format!("write: {e}"))?;
+    if !body.is_empty() {
+        stream
+            .write_all(body)
+            .map_err(|e| format!("write body: {e}"))?;
+    }
+
+    read_response(stream, max_response_bytes)
+}
+
+fn read_response(mut stream: TcpStream, max_response_bytes: usize) -> Result<HttpResponse, String> {
+    let mut response = Vec::new();
+    let mut chunk = [0u8; 4096];
+    loop {
+        let n = match stream.read(&mut chunk) {
+            Ok(n) => n,
+            Err(e) if e.kind() == std::io::ErrorKind::ConnectionReset && !response.is_empty() => {
+                break;
+            }
+            Err(e) => return Err(format!("read: {e}")),
+        };
+        if n == 0 {
+            break;
+        }
+        response.extend_from_slice(&chunk[..n]);
+        if response.len() > max_response_bytes {
+            return Err(format!("response exceeded {max_response_bytes} bytes"));
+        }
+    }
+
+    let split = response
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .ok_or_else(|| "bad HTTP response".to_string())?;
+    let (head, body_with_sep) = response.split_at(split);
+    let body = body_with_sep[4..].to_vec();
+    let head = std::str::from_utf8(head).map_err(|e| format!("headers utf8: {e}"))?;
+    let mut lines = head.lines();
+    let status_line = lines
+        .next()
+        .ok_or_else(|| "missing HTTP status".to_string())?;
+    let status = parse_status(status_line)?;
+    let mut etag = None;
+    for line in lines {
+        if let Some((name, value)) = line.split_once(':')
+            && name.trim().eq_ignore_ascii_case("etag")
+        {
+            etag = Some(value.trim().to_string());
+        }
+    }
+
+    Ok(HttpResponse { status, etag, body })
+}
+
+fn parse_status(status_line: &str) -> Result<u16, String> {
+    if !status_line.starts_with("HTTP/1.1 ") && !status_line.starts_with("HTTP/1.0 ") {
+        return Err("bad HTTP version".into());
+    }
+    status_line
+        .get(9..12)
+        .ok_or_else(|| "bad HTTP status".to_string())?
+        .parse::<u16>()
+        .map_err(|e| format!("bad HTTP status: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::net::TcpListener;
+    use std::thread;
+
+    fn with_server(response: &'static [u8], f: impl FnOnce(String)) {
+        with_server_checking_request(response, f, |_| {});
+    }
+
+    fn with_server_checking_request(
+        response: &'static [u8],
+        f: impl FnOnce(String),
+        check_request: impl FnOnce(&str) + Send + 'static,
+    ) {
+        let listener = match TcpListener::bind("127.0.0.1:0") {
+            Ok(listener) => listener,
+            Err(e)
+                if e.kind() == std::io::ErrorKind::PermissionDenied
+                    && std::env::var_os("TAPIO_LEAN_REQUIRE_NET").is_none() =>
+            {
+                eprintln!("SKIP httpc loopback test: loopback bind not permitted ({e})");
+                return;
+            }
+            Err(e) => panic!("loopback bind failed: {e}"),
+        };
+        let addr = listener.local_addr().unwrap();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0u8; 2048];
+            let n = stream.read(&mut request).unwrap();
+            check_request(&String::from_utf8_lossy(&request[..n]));
+            stream.write_all(response).unwrap();
+        });
+        f(format!("http://{addr}/v1/agents/config"));
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn get_parses_status_headers_and_body() {
+        with_server(
+            b"HTTP/1.1 200 OK\r\nETag: \"sha256:abc\"\r\nContent-Length: 2\r\n\r\n{}",
+            |url| {
+                let response = get(&url, &[], DEFAULT_TIMEOUT, DEFAULT_MAX_RESPONSE_BYTES).unwrap();
+                assert_eq!(response.status, 200);
+                assert_eq!(response.etag.as_deref(), Some("\"sha256:abc\""));
+                assert_eq!(response.body, b"{}");
+            },
+        );
+    }
+
+    #[test]
+    fn get_parses_not_modified_without_body() {
+        with_server(b"HTTP/1.1 304 Not Modified\r\n\r\n", |url| {
+            let response = get(
+                &url,
+                &[("If-None-Match", "\"sha256:abc\"".to_string())],
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_RESPONSE_BYTES,
+            )
+            .unwrap();
+            assert_eq!(response.status, 304);
+            assert!(response.body.is_empty());
+        });
+    }
+
+    #[test]
+    fn get_writes_if_none_match_header() {
+        with_server_checking_request(
+            b"HTTP/1.1 304 Not Modified\r\n\r\n",
+            |url| {
+                let response = get(
+                    &url,
+                    &[("If-None-Match", "\"sha256:abc\"".to_string())],
+                    DEFAULT_TIMEOUT,
+                    DEFAULT_MAX_RESPONSE_BYTES,
+                )
+                .unwrap();
+                assert_eq!(response.status, 304);
+            },
+            |request| assert!(request.contains("\r\nIf-None-Match: \"sha256:abc\"\r\n")),
+        );
+    }
+
+    #[test]
+    fn oversized_response_is_rejected() {
+        with_server(b"HTTP/1.1 200 OK\r\n\r\nabcdef", |url| {
+            let err = match get(&url, &[], DEFAULT_TIMEOUT, 3) {
+                Ok(_) => panic!("oversized response should fail"),
+                Err(err) => err,
+            };
+            assert!(err.contains("exceeded"));
+        });
+    }
+}

--- a/tapio-agent/src/httpc.rs
+++ b/tapio-agent/src/httpc.rs
@@ -5,11 +5,11 @@ use std::time::Duration;
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub const DEFAULT_MAX_RESPONSE_BYTES: usize = 1024 * 1024;
+const POST_MAX_RESPONSE_BYTES: usize = 8 * 1024;
 
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub struct HttpResponse {
     pub status: u16,
-    pub etag: Option<String>,
     pub body: Vec<u8>,
 }
 
@@ -30,7 +30,7 @@ pub fn post_json(endpoint: &str, body: &[u8]) -> Result<(), String> {
         &[("Content-Type", "application/json".to_string())],
         body,
         DEFAULT_TIMEOUT,
-        256,
+        POST_MAX_RESPONSE_BYTES,
     )?;
 
     if (200..300).contains(&response.status) {
@@ -118,16 +118,7 @@ fn read_response(mut stream: TcpStream, max_response_bytes: usize) -> Result<Htt
         .next()
         .ok_or_else(|| "missing HTTP status".to_string())?;
     let status = parse_status(status_line)?;
-    let mut etag = None;
-    for line in lines {
-        if let Some((name, value)) = line.split_once(':')
-            && name.trim().eq_ignore_ascii_case("etag")
-        {
-            etag = Some(value.trim().to_string());
-        }
-    }
-
-    Ok(HttpResponse { status, etag, body })
+    Ok(HttpResponse { status, body })
 }
 
 fn parse_status(status_line: &str) -> Result<u16, String> {
@@ -187,7 +178,6 @@ mod tests {
             |url| {
                 let response = get(&url, &[], DEFAULT_TIMEOUT, DEFAULT_MAX_RESPONSE_BYTES).unwrap();
                 assert_eq!(response.status, 200);
-                assert_eq!(response.etag.as_deref(), Some("\"sha256:abc\""));
                 assert_eq!(response.body, b"{}");
             },
         );
@@ -235,5 +225,13 @@ mod tests {
             };
             assert!(err.contains("exceeded"));
         });
+    }
+
+    #[test]
+    fn post_json_tolerates_verbose_2xx_response() {
+        with_server(
+            b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nX-Padding: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\r\nContent-Length: 64\r\n\r\n{\"accepted\":256,\"rejected\":0,\"next_config_version\":\"1\",\"x\":\"y\"}",
+            |url| post_json(&url, b"{}").unwrap(),
+        );
     }
 }

--- a/tapio-agent/src/main.rs
+++ b/tapio-agent/src/main.rs
@@ -1,9 +1,12 @@
 mod config;
+mod controller;
+mod httpc;
 mod metrics;
 mod observer;
 mod sink;
 
 use std::io::{self, Write};
+use std::time::Duration;
 use tracing::info;
 
 /// Stderr writer that silently swallows broken pipe errors.
@@ -26,12 +29,15 @@ impl Write for BrokenPipeGuard {
     }
 }
 
+#[derive(Debug)]
 struct Args {
     config: String,
     sinks: Vec<String>,
     ebpf_dir: String,
     data_dir: String,
     http_endpoint: String,
+    controller_endpoint: Option<String>,
+    config_poll_interval: Duration,
 }
 
 impl Default for Args {
@@ -42,15 +48,21 @@ impl Default for Args {
             ebpf_dir: "/opt/tapio/ebpf".into(),
             data_dir: ".tapio/occurrences".into(),
             http_endpoint: "http://localhost:8765".into(),
+            controller_endpoint: None,
+            config_poll_interval: Duration::from_secs(30),
         }
     }
 }
 
 impl Args {
     fn parse() -> anyhow::Result<Self> {
+        Self::parse_from(std::env::args().skip(1))
+    }
+
+    fn parse_from(values: impl IntoIterator<Item = String>) -> anyhow::Result<Self> {
         let mut args = Self::default();
         let mut explicit_sinks = Vec::new();
-        let mut iter = std::env::args().skip(1).peekable();
+        let mut iter = values.into_iter().peekable();
 
         while let Some(arg) = iter.next() {
             let (flag, inline_value) = match arg.split_once('=') {
@@ -72,6 +84,21 @@ impl Args {
                 "--ebpf-dir" => args.ebpf_dir = next_arg(flag, inline_value, &mut iter)?,
                 "--data-dir" => args.data_dir = next_arg(flag, inline_value, &mut iter)?,
                 "--http-endpoint" => args.http_endpoint = next_arg(flag, inline_value, &mut iter)?,
+                "--controller-endpoint" => {
+                    let endpoint = next_arg(flag, inline_value, &mut iter)?;
+                    validate_http_endpoint("--controller-endpoint", &endpoint)?;
+                    args.controller_endpoint = Some(endpoint);
+                }
+                "--config-poll-interval" => {
+                    let value = next_arg(flag, inline_value, &mut iter)?;
+                    let seconds = value.parse::<u64>().map_err(|e| {
+                        anyhow::anyhow!("--config-poll-interval must be seconds: {e}")
+                    })?;
+                    if seconds < 5 {
+                        anyhow::bail!("--config-poll-interval must be at least 5 seconds");
+                    }
+                    args.config_poll_interval = Duration::from_secs(seconds);
+                }
                 other => anyhow::bail!("unknown argument: {other}"),
             }
         }
@@ -82,6 +109,16 @@ impl Args {
 
         Ok(args)
     }
+}
+
+fn validate_http_endpoint(flag: &str, endpoint: &str) -> anyhow::Result<()> {
+    if endpoint.starts_with("https://") {
+        anyhow::bail!("{flag} does not support https://; use an explicit http:// endpoint");
+    }
+    if !endpoint.starts_with("http://") {
+        anyhow::bail!("{flag} must start with http://");
+    }
+    Ok(())
 }
 
 fn next_arg<I>(
@@ -126,6 +163,8 @@ Options:
   --ebpf-dir <path>        Directory containing compiled eBPF .o files [default: /opt/tapio/ebpf]
   --data-dir <path>        Directory for file sink output [default: .tapio/occurrences]
   --http-endpoint <url>    Endpoint for the http sink [default: http://localhost:8765]
+  --controller-endpoint <url> Controller config URL (http:// only)
+  --config-poll-interval <seconds> Config poll interval, minimum 5 [default: 30]
   -h, --help               Print help
   -V, --version            Print version",
         env!("CARGO_PKG_VERSION")
@@ -172,6 +211,25 @@ fn create_sinks(
         anyhow::bail!("at least one sink is required");
     }
     Ok(sinks)
+}
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn node_name() -> String {
+    std::env::var("TAPIO_NODE_NAME")
+        .or_else(|_| std::env::var("HOSTNAME"))
+        .unwrap_or_else(|_| "unknown-node".into())
+}
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn agent_id() -> String {
+    std::env::var("TAPIO_AGENT_ID").unwrap_or_else(|_| format!("node/{}", node_name()))
+}
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn config_file_mentions_thresholds(path: &std::path::Path) -> bool {
+    std::fs::read_to_string(path)
+        .map(|content| content.lines().any(|line| line.trim() == "[thresholds]"))
+        .unwrap_or(false)
 }
 
 /// Fan-out sink that sends to all inner sinks. Failure in one doesn't block others.
@@ -317,7 +375,26 @@ async fn main() -> anyhow::Result<()> {
         });
 
         let ebpf_dir = args.ebpf_dir.clone();
-        let tapio_config = cfg.tapio_config();
+        let controller_mode = args.controller_endpoint.is_some();
+        if controller_mode && config_file_mentions_thresholds(std::path::Path::new(&args.config)) {
+            tracing::warn!(
+                config = %args.config,
+                "TOML [thresholds] ignored"
+            );
+        }
+        let tapio_config = if controller_mode {
+            tapio_common::ebpf::TapioConfig::default()
+        } else {
+            cfg.tapio_config()
+        };
+        let carriers = observer::ConfigCarriers::default();
+        let standalone_thresholds = observer::node_pmc::PmcThresholds {
+            stall_pct_warning: cfg.thresholds.stall_pct_warning,
+            stall_pct_critical: cfg.thresholds.stall_pct_critical,
+            ipc_degradation: cfg.thresholds.ipc_degradation,
+        };
+        let (pmc_thresholds_tx, pmc_thresholds_rx) =
+            tokio::sync::watch::channel(standalone_thresholds);
         info!(
             generation = tapio_config.generation,
             flags = tapio_config.flags,
@@ -325,17 +402,47 @@ async fn main() -> anyhow::Result<()> {
         );
 
         let sink1: Arc<dyn tapio_common::sink::Sink> = multi_sink.clone();
+        let mut tasks = tokio::task::JoinSet::new();
+
+        if let Some(endpoint) = args.controller_endpoint.clone() {
+            tracing::info!(endpoint = %endpoint, "controller mode");
+            let controller = controller::ControllerConfig {
+                endpoint,
+                agent_id: agent_id(),
+                node_name: node_name(),
+                poll_interval: args.config_poll_interval,
+            };
+            let poll_carriers = carriers.clone();
+            let poll_thresholds = pmc_thresholds_tx.clone();
+            let poll_metrics = tapio_metrics.clone();
+            let poll_shutdown = shutdown_rx.clone();
+            tasks.spawn(async move {
+                controller::poll_loop(
+                    controller,
+                    poll_carriers,
+                    poll_thresholds,
+                    poll_metrics,
+                    poll_shutdown,
+                )
+                .await;
+            });
+        } else {
+            tracing::info!("standalone mode");
+        }
+
         let metrics1 = tapio_metrics.clone();
         let rx1 = shutdown_rx.clone();
         let dir1 = ebpf_dir.clone();
         let config1 = tapio_config;
-        let net = tokio::spawn(async move {
+        let carriers1 = carriers.clone();
+        tasks.spawn(async move {
             let path = format!("{dir1}/network_monitor.o");
             if let Err(e) = observer::network::run(
                 &path,
                 sink1.as_ref(),
                 boot_offset_ns,
                 config1,
+                &carriers1,
                 &metrics1,
                 rx1,
             )
@@ -350,13 +457,15 @@ async fn main() -> anyhow::Result<()> {
         let rx2 = shutdown_rx.clone();
         let dir2 = ebpf_dir.clone();
         let config2 = tapio_config;
-        let ctr = tokio::spawn(async move {
+        let carriers2 = carriers.clone();
+        tasks.spawn(async move {
             let path = format!("{dir2}/container_monitor.o");
             if let Err(e) = observer::container::run(
                 &path,
                 sink2.as_ref(),
                 boot_offset_ns,
                 config2,
+                &carriers2,
                 &metrics2,
                 rx2,
             )
@@ -371,13 +480,15 @@ async fn main() -> anyhow::Result<()> {
         let rx3 = shutdown_rx.clone();
         let dir3 = ebpf_dir.clone();
         let config3 = tapio_config;
-        let stg = tokio::spawn(async move {
+        let carriers3 = carriers.clone();
+        tasks.spawn(async move {
             let path = format!("{dir3}/storage_monitor.o");
             if let Err(e) = observer::storage::run(
                 &path,
                 sink3.as_ref(),
                 boot_offset_ns,
                 config3,
+                &carriers3,
                 &metrics3,
                 rx3,
             )
@@ -387,25 +498,25 @@ async fn main() -> anyhow::Result<()> {
             }
         });
 
-        let pmc_thresholds = observer::node_pmc::PmcThresholds {
-            stall_pct_warning: cfg.thresholds.stall_pct_warning,
-            stall_pct_critical: cfg.thresholds.stall_pct_critical,
-            ipc_degradation: cfg.thresholds.ipc_degradation,
-        };
-
         let sink4: Arc<dyn tapio_common::sink::Sink> = multi_sink.clone();
         let metrics4 = tapio_metrics.clone();
         let rx4 = shutdown_rx.clone();
         let dir4 = ebpf_dir.clone();
         let config4 = tapio_config;
-        let pmc = tokio::spawn(async move {
+        let carriers4 = carriers.clone();
+        let thresholds4 = pmc_thresholds_rx.clone();
+        let pmc_runtime = observer::node_pmc::PmcRuntimeConfig {
+            tapio_config: config4,
+            carriers: carriers4,
+            thresholds_rx: thresholds4,
+        };
+        tasks.spawn(async move {
             let path = format!("{dir4}/node_pmc_monitor.o");
             if let Err(e) = observer::node_pmc::run(
                 &path,
                 sink4.as_ref(),
                 boot_offset_ns,
-                config4,
-                pmc_thresholds,
+                pmc_runtime,
                 &metrics4,
                 rx4,
             )
@@ -415,7 +526,11 @@ async fn main() -> anyhow::Result<()> {
             }
         });
 
-        let _ = tokio::join!(net, ctr, stg, pmc);
+        while let Some(result) = tasks.join_next().await {
+            if let Err(e) = result {
+                tracing::error!(error = %e, "agent task failed");
+            }
+        }
         info!("all observers stopped");
         Ok(())
     }
@@ -595,5 +710,40 @@ mod tests {
             log_level_from_rust_log(Some("verbose")),
             tracing::level_filters::LevelFilter::ERROR
         );
+    }
+
+    #[test]
+    fn args_controller_endpoint_accepts_http_only() {
+        let args = Args::parse_from([
+            "--controller-endpoint".to_string(),
+            "http://controller:8080".to_string(),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            args.controller_endpoint.as_deref(),
+            Some("http://controller:8080")
+        );
+    }
+
+    #[test]
+    fn args_controller_endpoint_rejects_https() {
+        let err = Args::parse_from([
+            "--controller-endpoint".to_string(),
+            "https://controller:8443".to_string(),
+        ])
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("does not support https://"));
+    }
+
+    #[test]
+    fn args_config_poll_interval_enforces_minimum() {
+        let err = Args::parse_from(["--config-poll-interval".to_string(), "4".to_string()])
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("at least 5 seconds"));
     }
 }

--- a/tapio-agent/src/metrics.rs
+++ b/tapio-agent/src/metrics.rs
@@ -12,6 +12,7 @@ pub struct TapioMetrics {
     pub correlation_drops_total: CounterVec,
     pub drain_cap_total: CounterVec,
     pub sink_writes_total: CounterVec,
+    pub config_fetch_total: CounterVec,
 }
 
 #[derive(Clone)]
@@ -66,6 +67,11 @@ impl TapioMetrics {
                 "Total sink write attempts by result",
                 &["sink", "result"],
             ),
+            config_fetch_total: CounterVec::new(
+                "tapio_config_fetch_total",
+                "Controller config poll attempts by result",
+                &["result"],
+            ),
         })
     }
 
@@ -79,6 +85,7 @@ impl TapioMetrics {
             &self.correlation_drops_total,
             &self.drain_cap_total,
             &self.sink_writes_total,
+            &self.config_fetch_total,
         ] {
             counter.encode(&mut out);
         }

--- a/tapio-agent/src/observer/container.rs
+++ b/tapio-agent/src/observer/container.rs
@@ -222,6 +222,7 @@ pub async fn run(
     sink: &dyn tapio_common::sink::Sink,
     boot_offset_ns: u64,
     tapio_config: tapio_common::ebpf::TapioConfig,
+    carriers: &super::ConfigCarriers,
     metrics: &crate::metrics::TapioMetrics,
     mut shutdown: tokio::sync::watch::Receiver<bool>,
 ) -> anyhow::Result<()> {
@@ -230,7 +231,7 @@ pub async fn run(
 
     tracing::info!(path = ebpf_path, "loading container eBPF program");
     let mut ebpf = super::load_ebpf(ebpf_path, "container")?;
-    if !super::write_tapio_config(&mut ebpf, "container", &tapio_config) {
+    if !super::init_and_register_tapio_config(&mut ebpf, "container", &tapio_config, carriers) {
         anyhow::bail!("container observer: failed to initialize tapio_config carrier");
     }
 

--- a/tapio-agent/src/observer/mod.rs
+++ b/tapio-agent/src/observer/mod.rs
@@ -15,6 +15,83 @@ const METRIC_LOST_EVENTS: u32 = 0;
 #[cfg(target_os = "linux")]
 const METRIC_STORAGE_AMBIGUOUS_IO: u32 = 1;
 
+#[cfg(target_os = "linux")]
+#[derive(Clone, Default)]
+pub struct ConfigCarriers {
+    inner: std::sync::Arc<std::sync::Mutex<ConfigCarrierState>>,
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Clone, Copy)]
+struct ConfigCarrier {
+    observer: &'static str,
+    map_fd: std::os::fd::RawFd,
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Default)]
+struct ConfigCarrierState {
+    carriers: Vec<ConfigCarrier>,
+    current: Option<tapio_common::ebpf::TapioConfig>,
+}
+
+#[cfg(target_os = "linux")]
+impl ConfigCarriers {
+    pub fn register(&self, observer: &'static str, map_fd: std::os::fd::RawFd) {
+        let current = {
+            let mut state = self.inner.lock().expect("config carriers lock poisoned");
+            state.carriers.push(ConfigCarrier { observer, map_fd });
+            state.current
+        };
+        if let Some(config) = current {
+            match bpf_map_update_tapio_config(map_fd, &config) {
+                Ok(()) => {
+                    tracing::info!(
+                        observer,
+                        generation = config.generation,
+                        flags = config.flags,
+                        "config applied to late carrier"
+                    );
+                }
+                Err(e) => {
+                    tracing::error!(
+                        observer,
+                        map = "tapio_config",
+                        error = %e,
+                        generation = config.generation,
+                        "late config apply failed"
+                    );
+                }
+            }
+        }
+    }
+
+    pub fn update_all(&self, config: &tapio_common::ebpf::TapioConfig) -> Vec<&'static str> {
+        let carriers = {
+            let mut state = self.inner.lock().expect("config carriers lock poisoned");
+            state.current = Some(*config);
+            state.carriers.clone()
+        };
+        let mut failed = Vec::new();
+        for carrier in carriers {
+            match bpf_map_update_tapio_config(carrier.map_fd, config) {
+                Ok(()) => {}
+                Err(e) => {
+                    tracing::error!(
+                        observer = carrier.observer,
+                        map = "tapio_config",
+                        error = %e,
+                        generation = config.generation,
+                        "config fan-out failed"
+                    );
+                    failed.push(carrier.observer);
+                }
+            }
+        }
+        failed
+    }
+}
+
 /// Read a per-CPU u64 metric from a BPF PERCPU_ARRAY map by raw fd.
 /// Returns the sum across all CPUs, or 0 on error.
 #[cfg(target_os = "linux")]
@@ -128,23 +205,25 @@ fn bpf_map_update_tapio_config(
 }
 
 #[cfg(target_os = "linux")]
-pub fn write_tapio_config(
+pub fn init_and_register_tapio_config(
     ebpf: &mut aya::Ebpf,
     observer: &'static str,
     config: &tapio_common::ebpf::TapioConfig,
+    carriers: &ConfigCarriers,
 ) -> bool {
     let Some(map) = ebpf.map("tapio_config") else {
-        tracing::error!(observer, map = "tapio_config", "config carrier map missing");
+        tracing::error!(observer, map = "tapio_config", "config map missing");
         return false;
     };
     let map_fd = map_raw_fd(map);
     match bpf_map_update_tapio_config(map_fd, config) {
         Ok(()) => {
+            carriers.register(observer, map_fd);
             tracing::info!(
                 observer,
                 generation = config.generation,
                 flags = config.flags,
-                "tapio_config written to eBPF carrier"
+                "config carrier registered"
             );
             true
         }
@@ -153,7 +232,7 @@ pub fn write_tapio_config(
                 observer,
                 map = "tapio_config",
                 error = %e,
-                "failed to write tapio_config; observer remains at previous or zeroed config"
+                "config init failed"
             );
             false
         }

--- a/tapio-agent/src/observer/network.rs
+++ b/tapio-agent/src/observer/network.rs
@@ -157,6 +157,7 @@ pub async fn run(
     sink: &dyn tapio_common::sink::Sink,
     _boot_offset_ns: u64,
     tapio_config: tapio_common::ebpf::TapioConfig,
+    carriers: &super::ConfigCarriers,
     metrics: &crate::metrics::TapioMetrics,
     mut shutdown: tokio::sync::watch::Receiver<bool>,
 ) -> anyhow::Result<()> {
@@ -165,7 +166,7 @@ pub async fn run(
 
     tracing::info!(path = ebpf_path, "loading network eBPF program");
     let mut ebpf = super::load_ebpf(ebpf_path, "network")?;
-    if !super::write_tapio_config(&mut ebpf, "network", &tapio_config) {
+    if !super::init_and_register_tapio_config(&mut ebpf, "network", &tapio_config, carriers) {
         anyhow::bail!("network observer: failed to initialize tapio_config carrier");
     }
 

--- a/tapio-agent/src/observer/node_pmc.rs
+++ b/tapio-agent/src/observer/node_pmc.rs
@@ -2,10 +2,18 @@ use tapio_common::ebpf::*;
 use tapio_common::events::*;
 use tapio_common::occurrence::{Occurrence, Outcome, Severity};
 
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PmcThresholds {
     pub stall_pct_warning: f64,
     pub stall_pct_critical: f64,
     pub ipc_degradation: f64,
+}
+
+#[cfg(target_os = "linux")]
+pub struct PmcRuntimeConfig {
+    pub tapio_config: tapio_common::ebpf::TapioConfig,
+    pub carriers: super::ConfigCarriers,
+    pub thresholds_rx: tokio::sync::watch::Receiver<PmcThresholds>,
 }
 
 pub struct ClassifiedAnomaly {
@@ -239,8 +247,7 @@ pub async fn run(
     ebpf_path: &str,
     sink: &dyn tapio_common::sink::Sink,
     boot_offset_ns: u64,
-    tapio_config: tapio_common::ebpf::TapioConfig,
-    thresholds: PmcThresholds,
+    runtime: PmcRuntimeConfig,
     metrics: &crate::metrics::TapioMetrics,
     mut shutdown: tokio::sync::watch::Receiver<bool>,
 ) -> anyhow::Result<()> {
@@ -251,7 +258,12 @@ pub async fn run(
 
     tracing::info!(path = ebpf_path, "loading PMC eBPF program");
     let mut ebpf = super::load_ebpf(ebpf_path, "pmc")?;
-    if !super::write_tapio_config(&mut ebpf, "node_pmc", &tapio_config) {
+    if !super::init_and_register_tapio_config(
+        &mut ebpf,
+        "node_pmc",
+        &runtime.tapio_config,
+        &runtime.carriers,
+    ) {
         anyhow::bail!("node_pmc observer: failed to initialize tapio_config carrier");
     }
 
@@ -384,6 +396,7 @@ pub async fn run(
                         };
                         event_count += 1;
                         metrics.events_total.with_label_values(&["node_pmc"]).inc();
+                        let thresholds = *runtime.thresholds_rx.borrow();
                         if let Some(anomaly) = classify(&event, &thresholds) {
                             let occ = build_occurrence(&event, &anomaly, boot_offset_ns);
                             anomaly_count += 1;
@@ -466,6 +479,22 @@ mod tests {
     fn classify_normal_returns_none() {
         let evt = make_pmc(1000, 1500, 100); // IPC=1.5, stalls=10%
         assert!(classify(&evt, &default_thresholds()).is_none());
+    }
+
+    #[test]
+    fn watch_threshold_update_reaches_classify() {
+        let (tx, rx) = tokio::sync::watch::channel(default_thresholds());
+        let evt = make_pmc(1000, 1500, 250); // 25% stalls: warning under defaults.
+        assert!(classify(&evt, &rx.borrow()).is_some());
+
+        tx.send(PmcThresholds {
+            stall_pct_warning: 30.0,
+            stall_pct_critical: 60.0,
+            ipc_degradation: 1.0,
+        })
+        .unwrap();
+
+        assert!(classify(&evt, &rx.borrow()).is_none());
     }
 
     #[test]

--- a/tapio-agent/src/observer/storage.rs
+++ b/tapio-agent/src/observer/storage.rs
@@ -82,6 +82,7 @@ pub async fn run(
     sink: &dyn tapio_common::sink::Sink,
     boot_offset_ns: u64,
     tapio_config: tapio_common::ebpf::TapioConfig,
+    carriers: &super::ConfigCarriers,
     metrics: &crate::metrics::TapioMetrics,
     mut shutdown: tokio::sync::watch::Receiver<bool>,
 ) -> anyhow::Result<()> {
@@ -90,7 +91,7 @@ pub async fn run(
 
     tracing::info!(path = ebpf_path, "loading storage eBPF program");
     let mut ebpf = super::load_ebpf(ebpf_path, "storage")?;
-    if !super::write_tapio_config(&mut ebpf, "storage", &tapio_config) {
+    if !super::init_and_register_tapio_config(&mut ebpf, "storage", &tapio_config, carriers) {
         anyhow::bail!("storage observer: failed to initialize tapio_config carrier");
     }
 

--- a/tapio-agent/src/sink/http.rs
+++ b/tapio-agent/src/sink/http.rs
@@ -124,7 +124,7 @@ impl HttpSink {
             }
         };
 
-        match post_json(&self.endpoint, &payload) {
+        match crate::httpc::post_json(&self.endpoint, &payload) {
             Ok(()) => {
                 tracing::debug!(count = batch.len(), "http sink: batch sent");
                 if let Ok(mut inner) = self.inner.lock() {
@@ -152,56 +152,10 @@ impl HttpSink {
     }
 }
 
-/// Minimal HTTP POST using std::net::TcpStream.
-fn post_json(endpoint: &str, body: &[u8]) -> Result<(), String> {
-    use std::io::{Read, Write};
-    use std::net::TcpStream;
-
-    let url = endpoint
-        .strip_prefix("http://")
-        .ok_or_else(|| format!("endpoint must start with http://: {endpoint}"))?;
-
-    let (host_port, path) = match url.find('/') {
-        Some(i) => (&url[..i], &url[i..]),
-        None => (url, "/v1/occurrences"),
-    };
-
-    let mut stream =
-        TcpStream::connect(host_port).map_err(|e| format!("connect to {host_port}: {e}"))?;
-    stream.set_write_timeout(Some(Duration::from_secs(5))).ok();
-    stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
-
-    let request = format!(
-        "POST {path} HTTP/1.1\r\nHost: {host_port}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-        body.len()
-    );
-
-    stream
-        .write_all(request.as_bytes())
-        .map_err(|e| format!("write request: {e}"))?;
-    stream
-        .write_all(body)
-        .map_err(|e| format!("write body: {e}"))?;
-
-    let mut response = [0u8; 256];
-    let n = stream
-        .read(&mut response)
-        .map_err(|e| format!("read response: {e}"))?;
-    let status_line = String::from_utf8_lossy(&response[..n]);
-
-    if !status_line.starts_with("HTTP/1.1 2") && !status_line.starts_with("HTTP/1.0 2") {
-        return Err(format!(
-            "endpoint returned non-2xx: {}",
-            status_line.lines().next().unwrap_or("empty")
-        ));
-    }
-
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::httpc::post_json;
     use tapio_common::occurrence::{Outcome, Severity};
 
     fn occurrence() -> Occurrence {


### PR DESCRIPTION
## Summary
- add agent controller mode with `--controller-endpoint` and `--config-poll-interval`; standalone mode remains TOML-driven with generation 1
- extract the agent's tiny std::net HTTP/1.1 transport into `httpc` and use it for both config GET and the existing HTTP sink POST
- convert `tapio-wire::CompiledConfig` into `TapioConfig`, fan out live config to registered observer carriers, and update PMC userspace thresholds through a watch channel
- add `tapio_config_fetch_total{result=...}` and a controller-mode eBPF smoke script

## Mode and Config Behavior
- no `--controller-endpoint`: current standalone path, TOML thresholds, no controller network traffic
- `--controller-endpoint http://...`: controller mode; TOML `[thresholds]` is ignored with one warning if present; observers start from zeroed inert `TapioConfig` until the first config is fetched
- `https://` controller endpoints are rejected at flag parsing; no redirects are implemented
- poll path: `GET /v1/agents/config?agent_id=...&node_name=...` with `If-None-Match` after a hash is known; 200 applies, 304 no-ops, errors keep current config

## Budget / Size
Measured on Lima `ubuntu` Linux `6.17.0-29-generic` aarch64.

- PR agent release size: `1,186,824` bytes
- main baseline release size: `1,120,976` bytes
- delta: `+65,848` bytes
- target: `1,250,000` bytes, hard: `1,500,000` bytes
- map counts unchanged from PR2a budgets; lean eBPF budgets passed

## Dependency Impact
- added direct `tapio-wire` dependency to `tapio-agent`
- no reqwest, hyper, tonic, prost, YAML parser, Kubernetes crate, profile crate, or async HTTP stack added to the agent

## Tests / Verification
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo tree --workspace --duplicates` (no duplicate output)
- `git diff --check`
- Linux: `TMPDIR=/var/tmp OUT_DIR=/var/tmp/tapio-lean-pr3 scripts/verify-lean.sh` from a writable Linux copy: full pass; agent under target; eBPF object/map budgets passed
- Linux smoke: `TMPDIR=/var/tmp OUT_DIR=/var/tmp/tapio-smoke-controller-pr3 CARGO_TARGET_DIR=/var/tmp/tapio-smoke-controller-target scripts/smoke-ebpf-controller-config.sh`
  - OS/kernel: Linux lima-ubuntu `6.17.0-29-generic` aarch64
  - controller loaded profile and served generation `1`
  - agent started in controller mode and applied config
  - network observer loaded
  - triggered closed-port TCP connect on dst_port `50632`
  - observed occurrence with `config_generation: 1`

## Deferred
- PR4 active config hash/generation heartbeat reporting and degraded `Unconfigured` state
- last-known-good disk cache
- per-node/profile assignment
- controller profile hot reload
- controller status convergence views